### PR TITLE
Phase 4: lock content-pack strategy and deliver PPS/JM crisis-media expansion (#18, #19)

### DIFF
--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -1,32 +1,26 @@
 ---
 project: "To The Power"
 type: "build"
-lastUpdated: "2026-03-07"
+lastUpdated: "2026-03-12"
 ---
 
 # To The Power — Next Steps
 
 ## Immediate (This Session / Week)
 
-1. Build Phase 2 prototype shell that consumes `PrototypeApi` directly.
-2. Implement minimal UI flow:
-   - packet batch display
-   - challenge submit
-   - advance time
-   - state summary panel
-3. Add integration tests around prototype API usage patterns from UI state transitions.
-4. Add cohort-gate baseline check to CI-style command workflow.
+1. Start [#23](https://github.com/Oaks3000/to-the-power/issues/23) to formalize playtest loop thresholds and evidence template.
+2. Begin [#20](https://github.com/Oaks3000/to-the-power/issues/20) accessibility baseline hardening gate definition.
+3. Scope [#21](https://github.com/Oaks3000/to-the-power/issues/21) browser regression harness implementation details.
 
 ## Short Term (Next 2–4 Weeks)
 
-1. Expand content density in crisis/media and mid-career routes.
-2. Implement role progression gates and ending detection in domain flow.
-3. Add snapshot/golden tests for full scenario runs at fixed seeds.
-4. Add leaderboard/legacy scoring model skeleton.
-5. Scope persistence strategy for browser prototype sessions.
+1. Complete [#20](https://github.com/Oaks3000/to-the-power/issues/20) accessibility baseline and hardening gates.
+2. Build [#21](https://github.com/Oaks3000/to-the-power/issues/21) browser regression harness for shell core flow.
+3. Deliver [#22](https://github.com/Oaks3000/to-the-power/issues/22) retrospective/leaderboard productization slice.
+4. Recalculate Phase 4 release gates from playtest and harness results.
 
 ## Questions / Unknowns
 
-- Final target values for cohort gates over larger sweep sizes (200+ seeds).
-- Which role branch gets first polished narrative path in UI.
-- Whether to normalize remediation targets by challenge volume by default.
+- Which concrete release gate thresholds should be used for Tier 1 shell sign-off after broader playtests?
+- Whether additional domain/API surface is required before scaling from Backbencher to PPS/Junior Minister shells.
+- When to switch runtime defaults from `vertical-slice.json` to `content/index.json` after parity confidence.

--- a/.build/PHASE4_EXECUTION_MAP.md
+++ b/.build/PHASE4_EXECUTION_MAP.md
@@ -1,0 +1,44 @@
+---
+project: "To The Power"
+type: "build"
+phase: "Phase 4 — Content Expansion + Release Hardening"
+lastUpdated: "2026-03-12"
+---
+
+# Phase 4 Execution Map
+
+## Decision Lock
+
+- Content strategy lock: **A** (JSON packs + manifest index, with legacy `vertical-slice.json` compatibility retained).
+- Scope lock for first content increment: **PPS + Junior Minister crisis/media** only.
+- Increment size lock: **moderate** (+8 challenges, +6 event cards, +4 scenes).
+
+## Dependency Order
+
+1. [#18](https://github.com/Oaks3000/to-the-power/issues/18) — execution map + content strategy lock.
+2. [#19](https://github.com/Oaks3000/to-the-power/issues/19) — content expansion increment v1.
+3. [#23](https://github.com/Oaks3000/to-the-power/issues/23) — playtest loop and release thresholds.
+4. [#20](https://github.com/Oaks3000/to-the-power/issues/20) — accessibility baseline hardening gates.
+5. [#21](https://github.com/Oaks3000/to-the-power/issues/21) — browser regression harness.
+6. [#22](https://github.com/Oaks3000/to-the-power/issues/22) — retrospective/leaderboard productization.
+
+## Migration Notes (A -> future C optional)
+
+- Keep `content/vertical-slice.json` valid during transition.
+- Adopt `content/index.json` as pack manifest for new content growth.
+- Add new content in `content/packs/*.json` and merge via loader.
+- Move runtime defaults to manifest path only after parity and regression confidence is stable.
+- Revisit richer authoring format only if non-technical authoring/CMS/localization requirements justify migration cost.
+
+## Validation + Quality Gates for New Packs
+
+- Schema validity: merged bundle must pass `validateContentBundle`.
+- Referential integrity: all event card challenge/scene references must resolve.
+- Determinism parity: equivalent legacy and manifest bundles must pick identical packet outputs for fixed states/seeds.
+- Volume gate for #19 v1: PPS/Junior Minister crisis+media event card pool must increase and be measurable.
+- Regression gate: full `npm test` must pass before issue closeout.
+
+## Ownership Cadence
+
+- Build rhythm: paired decision gates with user sign-off before strategy or scope pivots.
+- Update cadence: refresh `.build/ROADMAP.md`, `.build/STATUS.md`, `.build/NEXT.md` at each issue closeout.

--- a/.build/ROADMAP.md
+++ b/.build/ROADMAP.md
@@ -2,14 +2,14 @@
 project: "To The Power"
 type: "build"
 createdAt: "2026-03-03"
-lastUpdated: "2026-03-07"
+lastUpdated: "2026-03-12"
 ---
 
 # To The Power — Roadmap
 
 A British political career simulation that teaches GCSE mathematics through consequential Westminster decision-making.
 
-## Current Phase: Phase 2.0 — Prototype API Surface
+## Current Phase: Phase 4 — Content Expansion + Release Hardening
 
 ### Phase 1: Domain + Engine Foundations (complete)
 - 1.0 Event-sourced architecture ✅
@@ -26,21 +26,39 @@ A British political career simulation that teaches GCSE mathematics through cons
 - 1.11 Scenario runner + balancing telemetry ✅
 - 1.12 Cohort confidence gates + baseline workflow ✅
 
-### Phase 2: Playable Browser Prototype (in progress)
+### Phase 2: Playable Browser Prototype (complete)
 - 2.0 Thin app-facing prototype API ✅
-- 2.1 Minimal browser shell scaffolding ⏳
-- 2.2 Packet/challenge/advance loop UI wiring ⏳
-- 2.3 Session persistence and resume ⏳
+- 2.1 Minimal browser shell scaffolding ✅ (issue [#2](https://github.com/Oaks3000/to-the-power/issues/2))
+- 2.2 Packet/challenge/advance loop UI wiring ✅ (issue [#3](https://github.com/Oaks3000/to-the-power/issues/3))
+- 2.3 Session persistence and resume ✅ (issue [#1](https://github.com/Oaks3000/to-the-power/issues/1))
+- 2.4 CI cohort-gate baseline check command ✅ (issue [#4](https://github.com/Oaks3000/to-the-power/issues/4))
 
-### Phase 3: Full UX Build
-- Narrative-first interaction design.
-- Progression/legacy/leaderboard full flow.
-- Tuning and polish from playtesting.
+### Phase 3: Full UX Build (complete)
+- 3.1 Career progression gates and failure-state evaluation ✅ (issue [#5](https://github.com/Oaks3000/to-the-power/issues/5))
+- 3.2 Visual design direction + interaction model
+  - Desk interaction architecture and affordance rules ✅ (issue [#7](https://github.com/Oaks3000/to-the-power/issues/7); spec: `.build/DESK_INTERACTION_ARCHITECTURE.md`)
+  - Tiered desk environment and role-to-space progression ✅ (issue [#6](https://github.com/Oaks3000/to-the-power/issues/6); spec: `.build/DESK_ENVIRONMENT_PROGRESSION.md`)
+- 3.3 Narrative-first shell redesign
+  - Diegetic packet and challenge presentation ✅ (issue [#9](https://github.com/Oaks3000/to-the-power/issues/9); spec: `.build/PACKET_PRESENTATION_SPEC.md`)
+  - Fallout surfaces: smartphone, newspapers, and publication pile ✅ (issue [#8](https://github.com/Oaks3000/to-the-power/issues/8); spec: `.build/FALLOUT_SURFACES_SPEC.md`)
+  - Tempo-driven environmental state and audio pressure ✅ (issue [#10](https://github.com/Oaks3000/to-the-power/issues/10); spec: `.build/TEMPO_PRESSURE_SPEC.md`)
+- 3.4 Legacy, retrospective, and leaderboard UX
+  - Career ending and retrospective presentation ✅ (issue [#12](https://github.com/Oaks3000/to-the-power/issues/12); spec: `.build/RETROSPECTIVE_PRESENTATION_SPEC.md`)
+- 3.5 Playtest-driven UX iteration
+  - Accessibility, responsive behavior, and input fallback for diegetic UI ✅ (issue [#11](https://github.com/Oaks3000/to-the-power/issues/11); spec: `.build/ACCESSIBILITY_INPUT_FALLBACK_SPEC.md`)
+- 3.6 Tier 1 polished desk shell implementation ✅ (issues [#13](https://github.com/Oaks3000/to-the-power/issues/13), [#14](https://github.com/Oaks3000/to-the-power/issues/14), [#15](https://github.com/Oaks3000/to-the-power/issues/15), [#16](https://github.com/Oaks3000/to-the-power/issues/16), [#17](https://github.com/Oaks3000/to-the-power/issues/17))
+  - Concrete implementation plan: `.build/TIER1_DESK_SHELL_IMPLEMENTATION_PLAN.md`
+  - Minimum operability checklist artifact: `.build/TIER1_MINIMUM_OPERABILITY_CHECKLIST.md`
+  - Visual direction lock: near-photoreal (stylised-real) desk presentation is required across all 3.6 slices, with full systemization in 3.6.5.
 
 ### Phase 4: Content Expansion + Release Hardening
-- Historical studies and training simulator integration.
-- Content depth expansion across roles/tempos/topics.
-- Accessibility, balancing, and release prep.
+- 4.1 Phase 4 execution map + content strategy lock ⏳ (issue [#18](https://github.com/Oaks3000/to-the-power/issues/18))
+- 4.2 Content expansion: crisis/media + mid-career routes ⏳ (issue [#19](https://github.com/Oaks3000/to-the-power/issues/19))
+- 4.3 Release accessibility baseline + hardening gates ⏳ (issue [#20](https://github.com/Oaks3000/to-the-power/issues/20))
+- 4.4 Browser regression harness for desk shell ⏳ (issue [#21](https://github.com/Oaks3000/to-the-power/issues/21))
+- 4.5 Retrospective and leaderboard productization ⏳ (issue [#22](https://github.com/Oaks3000/to-the-power/issues/22))
+- 4.6 Playtest loop and release threshold framework ⏳ (issue [#23](https://github.com/Oaks3000/to-the-power/issues/23))
+- Execution/dependency map artifact: `.build/PHASE4_EXECUTION_MAP.md`
 
 ## Out of Scope (for now)
 

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -2,51 +2,63 @@
 project: "To The Power"
 type: "build"
 priority: 1
-phase: "Phase 2.0 — Prototype API Surface"
-progress: 62
-lastUpdated: "2026-03-07"
-lastTouched: "2026-03-07"
+phase: "Phase 4 — Content Expansion + Release Hardening"
+progress: 0
+overallProgressEstimate: 88
+phaseIssueProgress: "2/6"
+lastUpdated: "2026-03-12"
+lastTouched: "2026-03-12"
 status: "in-progress"
 ---
 
 # To The Power — Current Status
 
-**Phase:** Phase 2.0 — Prototype API Surface (62% overall)
-**Last Updated:** 2026-03-07
+**Phase:** Phase 4 — Content Expansion + Release Hardening
+**Issue-tracked Phase Progress:** 33% (2 closed / 6 tracked issues)
+**Overall Project Progress (estimated):** 88%
+**Last Updated:** 2026-03-12
 
 ## What's Done
 
-- Event-sourced TypeScript core implemented with command/event validation.
-- Tempo-driven `timeHours` timeline and cadence policy implemented.
-- Deterministic content selection and tempo-aware packet batch selection implemented.
-- Encounter sequencing service implemented and integrated in `GameService`.
-- Mode/tempo consequence mapping implemented and wired through challenge outcomes.
-- Seeded scenario runner implemented for deterministic balancing runs.
-- Telemetry layer implemented:
-  - aggregate metrics
-  - per-seed outlier diagnostics
-  - confidence intervals
-  - cohort pass/fail gates
-- Baseline balancing workflow added (`npm run balance:baseline`) and documented.
-- Thin prototype application API implemented:
-  - `getCurrentPacketBatch`
-  - `submitChallengeOutcome`
-  - `advanceTime`
-  - `getStateSummary`
-- Public exports updated for prototype integration.
-- **34 tests passing**.
+- Phase 1 and Phase 2 implementation work remains complete.
+- Phase 3 design-spec tranche is complete and closed:
+  - [#6](https://github.com/Oaks3000/to-the-power/issues/6) through [#12](https://github.com/Oaks3000/to-the-power/issues/12) are closed.
+- Authoritative Phase 3 specs are in `.build/` for environment progression, interaction architecture, packets, fallout, tempo, retrospective, and accessibility.
+- Concrete implementation plan produced for first polished Tier 1 shell:
+  - `.build/TIER1_DESK_SHELL_IMPLEMENTATION_PLAN.md`
+- Phase 3 issue-tracked tranche is fully closed (12/12).
+- Phase 4 kickoff issue set opened:
+  - [#18](https://github.com/Oaks3000/to-the-power/issues/18) ✅
+  - [#19](https://github.com/Oaks3000/to-the-power/issues/19)
+  - [#20](https://github.com/Oaks3000/to-the-power/issues/20)
+  - [#21](https://github.com/Oaks3000/to-the-power/issues/21)
+  - [#22](https://github.com/Oaks3000/to-the-power/issues/22)
+  - [#23](https://github.com/Oaks3000/to-the-power/issues/23)
 
 ## What's In Progress
 
-- Phase 2 browser prototype shell (UI wiring to prototype API).
-- Final decision on release gate thresholds after broader seed-sweep runs.
+- Phase 4 kickoff has started with planning, content expansion, hardening, and automation tracks.
+- #19 implementation complete and closed:
+  - PPS/Junior Minister crisis/media pack increment delivered (+8 challenges, +6 event cards, +4 scenes)
+  - manifest loading support + parity/volume tests delivered
 
 ## Blockers
 
 - No technical blockers.
-- Main risk is UX integration speed and content depth pacing.
+
+## Issue Tracking Snapshot
+
+- Closed (Phase 3): [#6](https://github.com/Oaks3000/to-the-power/issues/6), [#7](https://github.com/Oaks3000/to-the-power/issues/7), [#8](https://github.com/Oaks3000/to-the-power/issues/8), [#9](https://github.com/Oaks3000/to-the-power/issues/9), [#10](https://github.com/Oaks3000/to-the-power/issues/10), [#11](https://github.com/Oaks3000/to-the-power/issues/11), [#12](https://github.com/Oaks3000/to-the-power/issues/12), [#13](https://github.com/Oaks3000/to-the-power/issues/13), [#14](https://github.com/Oaks3000/to-the-power/issues/14), [#15](https://github.com/Oaks3000/to-the-power/issues/15), [#16](https://github.com/Oaks3000/to-the-power/issues/16), [#17](https://github.com/Oaks3000/to-the-power/issues/17)
+- Closed (Phase 4): [#18](https://github.com/Oaks3000/to-the-power/issues/18), [#19](https://github.com/Oaks3000/to-the-power/issues/19)
+- Open (Phase 4): [#20](https://github.com/Oaks3000/to-the-power/issues/20), [#21](https://github.com/Oaks3000/to-the-power/issues/21), [#22](https://github.com/Oaks3000/to-the-power/issues/22), [#23](https://github.com/Oaks3000/to-the-power/issues/23)
 
 ## Notes
 
-- Cohort gates are now the primary balancing go/no-go signal.
-- Per-seed outliers remain diagnostic, not primary release criteria.
+- Tier 1 Backbencher remains the first polished route by design.
+- Accessibility, responsive behavior, and reduced-motion are implementation requirements for this tranche, not post-polish work.
+- Retrospective shell is specified, but productization remains downstream of Tier 1 loop stabilization.
+- Visual direction is now explicitly locked: Tier 1 should read near-photoreal (stylised-real), not flat/prototypical.
+- Minimum operability checklist for Tier 1 is now tracked in `.build/TIER1_MINIMUM_OPERABILITY_CHECKLIST.md`.
+- #13 final acceptance evidence was posted and #13 closed on 2026-03-12.
+- #18 final acceptance evidence was posted and #18 closed on 2026-03-14.
+- #19 final acceptance evidence was posted and #19 closed on 2026-03-14.

--- a/content/index.json
+++ b/content/index.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.2.0-phase4-kickoff",
+  "generatedAt": "2026-03-12",
+  "packs": [
+    "packs/pack-core-vertical-slice.json",
+    "packs/pack-phase4-pps-jm-crisis-media.json"
+  ]
+}

--- a/content/packs/pack-core-vertical-slice.json
+++ b/content/packs/pack-core-vertical-slice.json
@@ -1,0 +1,846 @@
+{
+  "id": "core-vertical-slice",
+  "description": "Baseline vertical slice content extracted into pack format.",
+  "challenges": [
+    {
+      "id": "ch_y9_pct_swing_01",
+      "topic": "percentages",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Local polling rose from 42% to 48%. What is the percentage point increase?",
+      "answer": 6,
+      "tolerance": 0,
+      "unit": "pp",
+      "tags": [
+        "constituency",
+        "polling"
+      ]
+    },
+    {
+      "id": "ch_y9_ratio_leaflets_01",
+      "topic": "ratio_proportion",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Leaflets are split in ratio 3:2 across two wards. If Ward A gets 1,800, how many go to Ward B?",
+      "answer": 1200,
+      "tolerance": 0,
+      "unit": "leaflets",
+      "tags": [
+        "campaign"
+      ]
+    },
+    {
+      "id": "ch_y9_std_form_debt_01",
+      "topic": "standard_form",
+      "band": "Y9",
+      "mode": "gate",
+      "prompt": "Write 3,400,000,000 in standard form (coefficient only, power stored separately in system).",
+      "answer": 3.4,
+      "tolerance": 0.0001,
+      "unit": "coefficient",
+      "tags": [
+        "treasury"
+      ]
+    },
+    {
+      "id": "ch_y9_linear_whip_01",
+      "topic": "linear_equations",
+      "band": "Y9",
+      "mode": "gate",
+      "prompt": "Whip says loyalty target follows y = 2x + 30. For x = 8 weeks, what is y?",
+      "answer": 46,
+      "tolerance": 0,
+      "unit": "score",
+      "tags": [
+        "whip"
+      ]
+    },
+    {
+      "id": "ch_y9_prob_vote_01",
+      "topic": "basic_probability",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Chance of passing bill is 0.65. Express as percentage.",
+      "answer": 65,
+      "tolerance": 0,
+      "unit": "%",
+      "tags": [
+        "parliament"
+      ]
+    },
+    {
+      "id": "ch_y9_stats_wait_01",
+      "topic": "statistics_basic",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Median waiting times are 10, 14, 12, 16, 8 weeks. What is the median?",
+      "answer": 12,
+      "tolerance": 0,
+      "unit": "weeks",
+      "tags": [
+        "health"
+      ]
+    },
+    {
+      "id": "ch_y9_round_budget_01",
+      "topic": "rounding",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Round 12.748 million to 1 decimal place.",
+      "answer": 12.7,
+      "tolerance": 0.01,
+      "unit": "million",
+      "tags": [
+        "budget"
+      ]
+    },
+    {
+      "id": "ch_y9_graph_gradient_01",
+      "topic": "linear_graphs",
+      "band": "Y9",
+      "mode": "gate",
+      "prompt": "A line goes through (0,2) and (4,10). What is its gradient?",
+      "answer": 2,
+      "tolerance": 0,
+      "unit": "gradient",
+      "tags": [
+        "data"
+      ]
+    },
+    {
+      "id": "ch_y9_substitution_01",
+      "topic": "substitution",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "For C = 5n + 20 and n = 12, find C.",
+      "answer": 80,
+      "tolerance": 0,
+      "unit": "cost",
+      "tags": [
+        "policy"
+      ]
+    },
+    {
+      "id": "ch_y9_seq_01",
+      "topic": "sequences_arithmetic",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Sequence is 7, 11, 15, ... What is term 8?",
+      "answer": 35,
+      "tolerance": 0,
+      "unit": "value",
+      "tags": [
+        "forecast"
+      ]
+    },
+    {
+      "id": "ch_y9_scatter_01",
+      "topic": "scatter_graphs",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "A stronger positive correlation should be coded as 1 and weak/no as 0. Data shows clear strong positive trend. Code?",
+      "answer": 1,
+      "tolerance": 0,
+      "unit": "code",
+      "tags": [
+        "analysis"
+      ]
+    },
+    {
+      "id": "ch_y9_powers_01",
+      "topic": "powers_roots",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Calculate 3 squared.",
+      "answer": 9,
+      "tolerance": 0,
+      "unit": "value",
+      "tags": [
+        "core"
+      ]
+    },
+    {
+      "id": "ch_y9_ratio_committee_01",
+      "topic": "ratio_proportion",
+      "band": "Y9",
+      "mode": "gate",
+      "prompt": "Committee seats split 5:3. If majority faction gets 25 seats, minority gets how many?",
+      "answer": 15,
+      "tolerance": 0,
+      "unit": "seats",
+      "tags": [
+        "committee"
+      ]
+    },
+    {
+      "id": "ch_y9_pct_cut_01",
+      "topic": "percentages",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Department budget falls from 80 to 68 million. What percent decrease?",
+      "answer": 15,
+      "tolerance": 0.1,
+      "unit": "%",
+      "tags": [
+        "budget"
+      ]
+    },
+    {
+      "id": "ch_y9_stats_mean_01",
+      "topic": "statistics_basic",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "Find mean of 6, 8, 10, 12, 14.",
+      "answer": 10,
+      "tolerance": 0,
+      "unit": "value",
+      "tags": [
+        "core"
+      ]
+    },
+    {
+      "id": "ch_y9_prob_single_01",
+      "topic": "basic_probability",
+      "band": "Y9",
+      "mode": "gate",
+      "prompt": "Probability of event is 1/4. As decimal?",
+      "answer": 0.25,
+      "tolerance": 0.0001,
+      "unit": "probability",
+      "tags": [
+        "risk"
+      ]
+    },
+    {
+      "id": "ch_y910_compound_01",
+      "topic": "compound_interest",
+      "band": "Y9-10",
+      "mode": "decision",
+      "prompt": "£1,000 grows by 5% for 2 years. Use A=P(1+r)^n.",
+      "answer": 1102.5,
+      "tolerance": 0.1,
+      "unit": "GBP",
+      "tags": [
+        "treasury"
+      ]
+    },
+    {
+      "id": "ch_y910_growth_01",
+      "topic": "growth_decay",
+      "band": "Y9-10",
+      "mode": "decision",
+      "prompt": "Population 200,000 grows 3% annually for one year. New population?",
+      "answer": 206000,
+      "tolerance": 1,
+      "unit": "people",
+      "tags": [
+        "home_office"
+      ]
+    },
+    {
+      "id": "ch_y910_simul_01",
+      "topic": "simultaneous_equations",
+      "band": "Y9-10",
+      "mode": "gate",
+      "prompt": "Solve: x + y = 14 and x - y = 2. Give x.",
+      "answer": 8,
+      "tolerance": 0,
+      "unit": "value",
+      "tags": [
+        "algebra"
+      ]
+    },
+    {
+      "id": "ch_y910_quad_01",
+      "topic": "quadratics_basic",
+      "band": "Y9-10",
+      "mode": "gate",
+      "prompt": "Solve x^2 - 5x + 6 = 0. Give the larger root.",
+      "answer": 3,
+      "tolerance": 0,
+      "unit": "root",
+      "tags": [
+        "algebra"
+      ]
+    },
+    {
+      "id": "ch_y910_tree_01",
+      "topic": "probability_trees",
+      "band": "Y9-10",
+      "mode": "decision",
+      "prompt": "A then B independent with probabilities 0.6 and 0.5. Probability of both?",
+      "answer": 0.3,
+      "tolerance": 0.0001,
+      "unit": "probability",
+      "tags": [
+        "risk"
+      ]
+    },
+    {
+      "id": "ch_y910_venn_01",
+      "topic": "venn_diagrams",
+      "band": "Y9-10",
+      "mode": "decision",
+      "prompt": "In 100 MPs, 60 support Bill A, 45 support Bill B, 25 support both. How many support at least one?",
+      "answer": 80,
+      "tolerance": 0,
+      "unit": "MPs",
+      "tags": [
+        "vote_math"
+      ]
+    },
+    {
+      "id": "ch_y910_hist_01",
+      "topic": "histograms",
+      "band": "Y9-10",
+      "mode": "decision",
+      "prompt": "Frequency density 4 over class width 5 gives frequency?",
+      "answer": 20,
+      "tolerance": 0,
+      "unit": "count",
+      "tags": [
+        "stats"
+      ]
+    },
+    {
+      "id": "ch_y910_direct_01",
+      "topic": "direct_inverse_proportion",
+      "band": "Y9-10",
+      "mode": "crisis",
+      "prompt": "y is directly proportional to x. y=18 when x=6. Find y when x=9.",
+      "answer": 27,
+      "tolerance": 0,
+      "unit": "value",
+      "timed": true,
+      "timerSeconds": 90,
+      "tags": [
+        "crisis"
+      ]
+    }
+  ],
+  "npcs": [
+    {
+      "id": "gerald_fosse",
+      "name": "Gerald Fosse",
+      "role": "Chief Whip",
+      "startingDisposition": 50
+    },
+    {
+      "id": "priya_sharma",
+      "name": "Priya Sharma",
+      "role": "Loyal Ally",
+      "startingDisposition": 68
+    },
+    {
+      "id": "helena_frost",
+      "name": "Dr. Helena Frost",
+      "role": "Treasury Spad",
+      "startingDisposition": 35
+    },
+    {
+      "id": "oliver_pemberton_cross",
+      "name": "Oliver Pemberton-Cross",
+      "role": "Spin Doctor",
+      "startingDisposition": 70
+    },
+    {
+      "id": "marcus_webb",
+      "name": "Marcus Webb",
+      "role": "Shadow Minister",
+      "startingDisposition": 25
+    },
+    {
+      "id": "vincent_harrold",
+      "name": "Vincent Harrold",
+      "role": "Press Baron",
+      "startingDisposition": 55
+    }
+  ],
+  "scenes": [
+    {
+      "id": "sc_whip_warning_01",
+      "npcId": "gerald_fosse",
+      "careerLevels": [
+        "backbencher",
+        "pps"
+      ],
+      "tempos": [
+        "parliamentary"
+      ],
+      "text": "Fosse slides over a whip sheet and taps one missing vote.",
+      "relationshipDelta": -2
+    },
+    {
+      "id": "sc_priya_support_01",
+      "npcId": "priya_sharma",
+      "careerLevels": [
+        "backbencher",
+        "pps",
+        "junior_minister"
+      ],
+      "tempos": [
+        "recess",
+        "parliamentary"
+      ],
+      "text": "Priya offers canvassing volunteers if you back her amendment.",
+      "relationshipDelta": 2
+    },
+    {
+      "id": "sc_frost_brief_01",
+      "npcId": "helena_frost",
+      "careerLevels": [
+        "pps",
+        "junior_minister",
+        "minister_of_state"
+      ],
+      "tempos": [
+        "parliamentary",
+        "crisis"
+      ],
+      "text": "Frost circles one equation and says, 'Start with the multiplier.'",
+      "relationshipDelta": 1
+    },
+    {
+      "id": "sc_oliver_spin_01",
+      "npcId": "oliver_pemberton_cross",
+      "careerLevels": [
+        "pps",
+        "junior_minister",
+        "minister_of_state"
+      ],
+      "tempos": [
+        "media_storm",
+        "crisis"
+      ],
+      "text": "Oliver drafts three headlines and marks the least damaging in green.",
+      "relationshipDelta": 1
+    },
+    {
+      "id": "sc_webb_attack_01",
+      "npcId": "marcus_webb",
+      "careerLevels": [
+        "junior_minister",
+        "minister_of_state",
+        "cabinet"
+      ],
+      "tempos": [
+        "parliamentary",
+        "media_storm"
+      ],
+      "text": "Webb quotes your own numbers back at you and asks who signed them off.",
+      "relationshipDelta": -2
+    },
+    {
+      "id": "sc_harrold_call_01",
+      "npcId": "vincent_harrold",
+      "careerLevels": [
+        "minister_of_state",
+        "cabinet",
+        "pm"
+      ],
+      "tempos": [
+        "media_storm",
+        "crisis"
+      ],
+      "text": "Harrold offers a friendly front page in return for early access to data.",
+      "relationshipDelta": -1
+    },
+    {
+      "id": "sc_backbench_crisis_whip_01",
+      "npcId": "gerald_fosse",
+      "careerLevels": [
+        "backbencher"
+      ],
+      "tempos": [
+        "crisis"
+      ],
+      "text": "Fosse corners you outside the chamber: vote math is collapsing by the hour.",
+      "relationshipDelta": -1
+    },
+    {
+      "id": "sc_backbench_media_spin_01",
+      "npcId": "oliver_pemberton_cross",
+      "careerLevels": [
+        "backbencher",
+        "pps"
+      ],
+      "tempos": [
+        "media_storm"
+      ],
+      "text": "Oliver slides a flash card of three numbers and mouths, say these and not the others.",
+      "relationshipDelta": 1
+    }
+  ],
+  "eventCards": [
+    {
+      "id": "ev_constituency_polling_01",
+      "title": "Marginal Seat Nerves",
+      "description": "Constituency swing model needed before weekend campaign push.",
+      "careerLevels": [
+        "backbencher"
+      ],
+      "tempos": [
+        "parliamentary",
+        "recess"
+      ],
+      "bands": [
+        "Y9"
+      ],
+      "candidateChallengeIds": [
+        "ch_y9_pct_swing_01",
+        "ch_y9_ratio_leaflets_01"
+      ],
+      "candidateSceneIds": [
+        "sc_priya_support_01",
+        "sc_whip_warning_01"
+      ],
+      "weight": 1.2
+    },
+    {
+      "id": "ev_committee_screening_01",
+      "title": "Committee Screening",
+      "description": "Whip's office requests arithmetic checks before shortlist confirmation.",
+      "careerLevels": [
+        "backbencher",
+        "pps"
+      ],
+      "tempos": [
+        "parliamentary"
+      ],
+      "bands": [
+        "Y9"
+      ],
+      "candidateChallengeIds": [
+        "ch_y9_linear_whip_01",
+        "ch_y9_ratio_committee_01",
+        "ch_y9_prob_single_01"
+      ],
+      "candidateSceneIds": [
+        "sc_whip_warning_01"
+      ],
+      "weight": 1.3
+    },
+    {
+      "id": "ev_local_service_brief_01",
+      "title": "Local Service Backlog",
+      "description": "Briefing pack compares waiting lists and local outcomes.",
+      "careerLevels": [
+        "backbencher",
+        "pps"
+      ],
+      "tempos": [
+        "parliamentary",
+        "recess"
+      ],
+      "bands": [
+        "Y9"
+      ],
+      "candidateChallengeIds": [
+        "ch_y9_stats_wait_01",
+        "ch_y9_stats_mean_01",
+        "ch_y9_round_budget_01"
+      ],
+      "candidateSceneIds": [
+        "sc_priya_support_01"
+      ],
+      "weight": 1
+    },
+    {
+      "id": "ev_treasury_shadow_task_01",
+      "title": "Treasury Shadow Task",
+      "description": "Frost asks for a quick debt-growth estimate before PM sees it.",
+      "careerLevels": [
+        "pps",
+        "junior_minister"
+      ],
+      "tempos": [
+        "parliamentary",
+        "crisis"
+      ],
+      "bands": [
+        "Y9",
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y910_compound_01",
+        "ch_y910_growth_01",
+        "ch_y9_std_form_debt_01"
+      ],
+      "candidateSceneIds": [
+        "sc_frost_brief_01"
+      ],
+      "weight": 1.5
+    },
+    {
+      "id": "ev_crossbench_math_01",
+      "title": "Crossbench Arithmetic",
+      "description": "Vote margin depends on alliance maths by close of play.",
+      "careerLevels": [
+        "pps",
+        "junior_minister"
+      ],
+      "tempos": [
+        "parliamentary"
+      ],
+      "bands": [
+        "Y9",
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y910_venn_01",
+        "ch_y910_tree_01",
+        "ch_y9_prob_vote_01"
+      ],
+      "candidateSceneIds": [
+        "sc_whip_warning_01",
+        "sc_priya_support_01"
+      ],
+      "weight": 1.4
+    },
+    {
+      "id": "ev_media_numbers_01",
+      "title": "Numbers on Air",
+      "description": "A live interview forces rapid figures under pressure.",
+      "careerLevels": [
+        "pps",
+        "junior_minister",
+        "minister_of_state"
+      ],
+      "tempos": [
+        "media_storm",
+        "crisis"
+      ],
+      "bands": [
+        "Y9",
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y910_direct_01",
+        "ch_y9_graph_gradient_01"
+      ],
+      "candidateSceneIds": [
+        "sc_oliver_spin_01",
+        "sc_webb_attack_01"
+      ],
+      "weight": 1.6
+    },
+    {
+      "id": "ev_department_tradeoff_01",
+      "title": "Department Trade-Off",
+      "description": "Two funding promises conflict; model both before briefing room opens.",
+      "careerLevels": [
+        "junior_minister",
+        "minister_of_state"
+      ],
+      "tempos": [
+        "parliamentary",
+        "crisis"
+      ],
+      "bands": [
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y910_simul_01",
+        "ch_y910_quad_01",
+        "ch_y910_hist_01"
+      ],
+      "candidateSceneIds": [
+        "sc_frost_brief_01",
+        "sc_webb_attack_01"
+      ],
+      "weight": 1.7
+    },
+    {
+      "id": "ev_budget_clip_01",
+      "title": "Unexpected Budget Clip",
+      "description": "Mid-cycle cut requires fast percentage and ratio reallocations.",
+      "careerLevels": [
+        "pps",
+        "junior_minister",
+        "minister_of_state"
+      ],
+      "tempos": [
+        "crisis"
+      ],
+      "bands": [
+        "Y9",
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y9_pct_cut_01",
+        "ch_y9_ratio_leaflets_01",
+        "ch_y910_growth_01"
+      ],
+      "candidateSceneIds": [
+        "sc_frost_brief_01",
+        "sc_oliver_spin_01"
+      ],
+      "weight": 1.8
+    },
+    {
+      "id": "ev_shadow_scrutiny_01",
+      "title": "Shadow Scrutiny",
+      "description": "Opposition picks one weak statistic and pushes it hard.",
+      "careerLevels": [
+        "junior_minister",
+        "minister_of_state",
+        "cabinet"
+      ],
+      "tempos": [
+        "parliamentary",
+        "media_storm"
+      ],
+      "bands": [
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y910_hist_01",
+        "ch_y910_venn_01",
+        "ch_y9_scatter_01"
+      ],
+      "candidateSceneIds": [
+        "sc_webb_attack_01"
+      ],
+      "weight": 1.5
+    },
+    {
+      "id": "ev_press_bargain_01",
+      "title": "Press Bargain",
+      "description": "A soft profile is offered if your figures withstand scrutiny.",
+      "careerLevels": [
+        "minister_of_state",
+        "cabinet",
+        "pm"
+      ],
+      "tempos": [
+        "media_storm",
+        "crisis"
+      ],
+      "bands": [
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y910_tree_01",
+        "ch_y910_direct_01"
+      ],
+      "candidateSceneIds": [
+        "sc_harrold_call_01",
+        "sc_oliver_spin_01"
+      ],
+      "weight": 1.9
+    },
+    {
+      "id": "ev_backbench_crisis_whipcount_01",
+      "title": "Emergency Whipcount",
+      "description": "A late rebellion threat forces immediate headcount arithmetic before division bells.",
+      "careerLevels": [
+        "backbencher"
+      ],
+      "tempos": [
+        "crisis"
+      ],
+      "bands": [
+        "Y9"
+      ],
+      "candidateChallengeIds": [
+        "ch_y9_prob_vote_01",
+        "ch_y9_ratio_committee_01",
+        "ch_y9_linear_whip_01"
+      ],
+      "candidateSceneIds": [
+        "sc_backbench_crisis_whip_01",
+        "sc_whip_warning_01"
+      ],
+      "weight": 1.7
+    },
+    {
+      "id": "ev_backbench_media_scrum_01",
+      "title": "Lobby Scrum Numbers",
+      "description": "Cameras are live and your figure gets challenged before your adviser reaches you.",
+      "careerLevels": [
+        "backbencher",
+        "pps"
+      ],
+      "tempos": [
+        "media_storm"
+      ],
+      "bands": [
+        "Y9"
+      ],
+      "candidateChallengeIds": [
+        "ch_y9_pct_swing_01",
+        "ch_y9_round_budget_01",
+        "ch_y9_stats_mean_01"
+      ],
+      "candidateSceneIds": [
+        "sc_backbench_media_spin_01",
+        "sc_oliver_spin_01"
+      ],
+      "weight": 1.6
+    },
+    {
+      "id": "ev_pps_crisis_briefing_01",
+      "title": "PPS Rapid Brief",
+      "description": "You have minutes to reconcile conflicting figures before ministerial line to take is set.",
+      "careerLevels": [
+        "pps"
+      ],
+      "tempos": [
+        "crisis"
+      ],
+      "bands": [
+        "Y9",
+        "Y9-10"
+      ],
+      "candidateChallengeIds": [
+        "ch_y910_tree_01",
+        "ch_y9_graph_gradient_01",
+        "ch_y910_growth_01"
+      ],
+      "candidateSceneIds": [
+        "sc_frost_brief_01",
+        "sc_backbench_media_spin_01"
+      ],
+      "weight": 1.8
+    }
+  ],
+  "briefings": [
+    {
+      "id": "br_frost_compound_01",
+      "advisor": "Dr. Helena Frost",
+      "topic": "compound_interest",
+      "bands": [
+        "Y9-10"
+      ],
+      "text": "Use multipliers first; round only at the end."
+    },
+    {
+      "id": "br_fosse_probability_01",
+      "advisor": "Gerald Fosse",
+      "topic": "basic_probability",
+      "bands": [
+        "Y9",
+        "Y9-10"
+      ],
+      "text": "Count heads, then count rebels, then remove wishful thinking."
+    },
+    {
+      "id": "br_oliver_stats_01",
+      "advisor": "Oliver Pemberton-Cross",
+      "topic": "statistics_basic",
+      "bands": [
+        "Y9"
+      ],
+      "text": "One clean number beats five noisy ones on camera."
+    },
+    {
+      "id": "br_chen_tree_01",
+      "advisor": "Zara Chen",
+      "topic": "probability_trees",
+      "bands": [
+        "Y9-10"
+      ],
+      "text": "Label every branch, then multiply along paths before adding outcomes."
+    }
+  ]
+}

--- a/content/packs/pack-phase4-pps-jm-crisis-media.json
+++ b/content/packs/pack-phase4-pps-jm-crisis-media.json
@@ -1,0 +1,238 @@
+{
+  "id": "phase4-pps-jm-crisis-media-v1",
+  "description": "Phase 4 kickoff content increment focused on PPS/Junior Minister crisis and media-storm density.",
+  "challenges": [
+    {
+      "id": "ch_phase4_pps_crisis_bounds_01",
+      "topic": "bounds",
+      "band": "Y9",
+      "mode": "crisis",
+      "prompt": "Department estimate is 48.6 million with a tolerance of +/-0.4 million. What is the upper bound?",
+      "answer": 49,
+      "tolerance": 0.05,
+      "unit": "million",
+      "tags": ["pps", "crisis", "department"]
+    },
+    {
+      "id": "ch_phase4_pps_media_indices_01",
+      "topic": "indices",
+      "band": "Y9",
+      "mode": "decision",
+      "prompt": "A media pressure index is recorded as 2^5. Calculate the index value.",
+      "answer": 32,
+      "tolerance": 0,
+      "unit": "index",
+      "tags": ["pps", "media"]
+    },
+    {
+      "id": "ch_phase4_pps_crisis_ineq_01",
+      "topic": "inequalities",
+      "band": "Y9",
+      "mode": "gate",
+      "prompt": "You need at least 42 MPs and already have 29. Solve 29 + x >= 42. What is the minimum x?",
+      "answer": 13,
+      "tolerance": 0,
+      "unit": "MPs",
+      "tags": ["pps", "whips"]
+    },
+    {
+      "id": "ch_phase4_pps_crisis_rate_01",
+      "topic": "rates_of_change_linear",
+      "band": "Y9-10",
+      "mode": "crisis",
+      "prompt": "Case backlog rises from 840 to 1,020 over 6 hours. What is the hourly rate of increase?",
+      "answer": 30,
+      "tolerance": 0,
+      "unit": "cases/hour",
+      "tags": ["pps", "operations", "crisis"]
+    },
+    {
+      "id": "ch_phase4_jm_crisis_prob_tree_01",
+      "topic": "probability_trees",
+      "band": "Y9-10",
+      "mode": "crisis",
+      "prompt": "Briefing says chance of disruption is 0.3 and chance of major impact given disruption is 0.4. What is P(disruption and major impact)?",
+      "answer": 0.12,
+      "tolerance": 0.0001,
+      "unit": "probability",
+      "tags": ["junior_minister", "risk"]
+    },
+    {
+      "id": "ch_phase4_jm_media_cfreq_01",
+      "topic": "cumulative_frequency",
+      "band": "Y9-10",
+      "mode": "decision",
+      "prompt": "A cumulative chart shows 68 stories at or below tone score 5 out of 100. What percentage is at or below 5?",
+      "answer": 68,
+      "tolerance": 0,
+      "unit": "%",
+      "tags": ["junior_minister", "media"]
+    },
+    {
+      "id": "ch_phase4_jm_crisis_functions_01",
+      "topic": "functions",
+      "band": "Y10-11",
+      "mode": "gate",
+      "prompt": "Policy response function is f(x) = 3x + 4. Evaluate f(12).",
+      "answer": 40,
+      "tolerance": 0,
+      "unit": "score",
+      "tags": ["junior_minister", "policy"]
+    },
+    {
+      "id": "ch_phase4_jm_media_critique_01",
+      "topic": "statistical_critique",
+      "band": "Y10-11",
+      "mode": "decision",
+      "prompt": "A headline compares a sample of 20 with a national claim. Enter 1 if the sample is likely too small, else 0.",
+      "answer": 1,
+      "tolerance": 0,
+      "unit": "flag",
+      "tags": ["junior_minister", "media", "analysis"]
+    }
+  ],
+  "npcs": [],
+  "scenes": [
+    {
+      "id": "sc_phase4_pps_war_room_01",
+      "npcId": "oliver_pemberton_cross",
+      "careerLevels": ["pps"],
+      "tempos": ["crisis", "media_storm"],
+      "text": "Oliver slides a live dashboard across the desk: \"Numbers are moving faster than statements. Lock the line before noon.\"",
+      "relationshipDelta": -1
+    },
+    {
+      "id": "sc_phase4_pps_whips_corridor_01",
+      "npcId": "gerald_fosse",
+      "careerLevels": ["pps"],
+      "tempos": ["crisis"],
+      "text": "Gerald keeps his voice low: \"I can hold one rebellion, not two. Give me clean arithmetic and now.\"",
+      "relationshipDelta": 1
+    },
+    {
+      "id": "sc_phase4_jm_broadcast_drill_01",
+      "npcId": "helena_frost",
+      "careerLevels": ["junior_minister"],
+      "tempos": ["media_storm"],
+      "text": "Helena circles a quote on your draft: \"If you can't defend the number on-air, don't use it.\"",
+      "relationshipDelta": 1
+    },
+    {
+      "id": "sc_phase4_jm_select_committee_ping_01",
+      "npcId": "marcus_webb",
+      "careerLevels": ["junior_minister"],
+      "tempos": ["crisis", "media_storm"],
+      "text": "Marcus has already posted: \"Committee wants your figures reconciled before questions. Clock is running.\"",
+      "relationshipDelta": -2
+    }
+  ],
+  "eventCards": [
+    {
+      "id": "ev_phase4_pps_crisis_flood_grid_01",
+      "title": "Flood Grid Breakdown",
+      "description": "Regional response maps conflict and whips demand a single number before PMQs.",
+      "careerLevels": ["pps"],
+      "tempos": ["crisis"],
+      "bands": ["Y9"],
+      "candidateChallengeIds": [
+        "ch_phase4_pps_crisis_bounds_01",
+        "ch_phase4_pps_crisis_rate_01",
+        "ch_y9_round_budget_01"
+      ],
+      "candidateSceneIds": [
+        "sc_phase4_pps_whips_corridor_01",
+        "sc_phase4_pps_war_room_01"
+      ],
+      "weight": 1.45
+    },
+    {
+      "id": "ev_phase4_pps_media_clipcycle_01",
+      "title": "Clip Cycle Escalation",
+      "description": "A selective media clip is trending and your office must counter with numerically solid framing.",
+      "careerLevels": ["pps"],
+      "tempos": ["media_storm"],
+      "bands": ["Y9"],
+      "candidateChallengeIds": [
+        "ch_phase4_pps_media_indices_01",
+        "ch_y9_pct_cut_01"
+      ],
+      "candidateSceneIds": [
+        "sc_phase4_pps_war_room_01",
+        "sc_oliver_spin_01"
+      ],
+      "weight": 1.25
+    },
+    {
+      "id": "ev_phase4_pps_crisis_whipline_01",
+      "title": "Whipline Arithmetic",
+      "description": "Late defections force a rapid inequality check before the division bell.",
+      "careerLevels": ["pps"],
+      "tempos": ["crisis"],
+      "bands": ["Y9"],
+      "candidateChallengeIds": [
+        "ch_phase4_pps_crisis_ineq_01",
+        "ch_y9_linear_whip_01"
+      ],
+      "candidateSceneIds": [
+        "sc_phase4_pps_whips_corridor_01",
+        "sc_whip_warning_01"
+      ],
+      "weight": 1.3
+    },
+    {
+      "id": "ev_phase4_jm_crisis_supply_01",
+      "title": "Supply Chain Red Window",
+      "description": "Department logistics has entered a red state and ministers need a risk-weighted update.",
+      "careerLevels": ["junior_minister"],
+      "tempos": ["crisis"],
+      "bands": ["Y9-10", "Y10-11"],
+      "candidateChallengeIds": [
+        "ch_phase4_jm_crisis_prob_tree_01",
+        "ch_phase4_pps_crisis_rate_01",
+        "ch_y910_growth_01"
+      ],
+      "candidateSceneIds": [
+        "sc_phase4_jm_select_committee_ping_01",
+        "sc_harrold_call_01"
+      ],
+      "weight": 1.5
+    },
+    {
+      "id": "ev_phase4_jm_media_forensics_01",
+      "title": "Broadcast Forensics Panel",
+      "description": "A live panel will challenge your denominator and sampling logic in real time.",
+      "careerLevels": ["junior_minister"],
+      "tempos": ["media_storm"],
+      "bands": ["Y9-10", "Y10-11"],
+      "candidateChallengeIds": [
+        "ch_phase4_jm_media_cfreq_01",
+        "ch_phase4_jm_media_critique_01",
+        "ch_y910_compound_01"
+      ],
+      "candidateSceneIds": [
+        "sc_phase4_jm_broadcast_drill_01",
+        "sc_phase4_jm_select_committee_ping_01"
+      ],
+      "weight": 1.4
+    },
+    {
+      "id": "ev_phase4_jm_crisis_committee_sheet_01",
+      "title": "Committee Numbers Sheet",
+      "description": "Cross-party committee requests a unified response function before publication.",
+      "careerLevels": ["junior_minister"],
+      "tempos": ["crisis", "media_storm"],
+      "bands": ["Y9-10", "Y10-11"],
+      "candidateChallengeIds": [
+        "ch_phase4_jm_crisis_functions_01",
+        "ch_phase4_jm_media_critique_01",
+        "ch_y910_simul_01"
+      ],
+      "candidateSceneIds": [
+        "sc_phase4_jm_select_committee_ping_01",
+        "sc_frost_brief_01"
+      ],
+      "weight": 1.35
+    }
+  ],
+  "briefings": []
+}

--- a/dist/content/loader.js
+++ b/dist/content/loader.js
@@ -1,8 +1,62 @@
 import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { validateContentBundle } from "./schema.js";
+function isRecord(value) {
+    return typeof value === "object" && value !== null;
+}
+function isStringArray(value) {
+    return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+function isManifest(value) {
+    if (!isRecord(value)) {
+        return false;
+    }
+    return (typeof value.version === "string" &&
+        typeof value.generatedAt === "string" &&
+        isStringArray(value.packs));
+}
+function assertPack(value, pathLabel) {
+    if (!isRecord(value) || typeof value.id !== "string") {
+        throw new Error(`Invalid content pack at ${pathLabel}: missing id`);
+    }
+    const arrayKeys = ["challenges", "npcs", "scenes", "eventCards", "briefings"];
+    for (const key of arrayKeys) {
+        if (!Array.isArray(value[key])) {
+            throw new Error(`Invalid content pack at ${pathLabel}: ${key} must be an array`);
+        }
+    }
+}
+async function loadManifestBundle(manifest, manifestPath) {
+    const manifestDir = dirname(manifestPath);
+    const merged = {
+        version: manifest.version,
+        generatedAt: manifest.generatedAt,
+        challenges: [],
+        npcs: [],
+        scenes: [],
+        eventCards: [],
+        briefings: []
+    };
+    for (const packRef of manifest.packs) {
+        const packPath = resolve(manifestDir, packRef);
+        const rawPack = await readFile(packPath, "utf8");
+        const parsedPack = JSON.parse(rawPack);
+        assertPack(parsedPack, packRef);
+        merged.challenges.push(...parsedPack.challenges);
+        merged.npcs.push(...parsedPack.npcs);
+        merged.scenes.push(...parsedPack.scenes);
+        merged.eventCards.push(...parsedPack.eventCards);
+        merged.briefings.push(...parsedPack.briefings);
+    }
+    validateContentBundle(merged);
+    return merged;
+}
 export async function loadContentBundle(filePath) {
     const raw = await readFile(filePath, "utf8");
     const parsed = JSON.parse(raw);
+    if (isManifest(parsed)) {
+        return loadManifestBundle(parsed, filePath);
+    }
     const bundle = parsed;
     validateContentBundle(bundle);
     return bundle;

--- a/dist/tests/content-selection.test.js
+++ b/dist/tests/content-selection.test.js
@@ -1,13 +1,14 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import { applyEvent } from "../domain/reducer.js";
 import { createInitialGameState } from "../domain/state.js";
+import { loadContentBundle } from "../content/loader.js";
 import { selectCurrentContent, selectCurrentContentBatch } from "../content/selection.js";
 async function loadBundle() {
-    const raw = await readFile(resolve(process.cwd(), "content/vertical-slice.json"), "utf8");
-    return JSON.parse(raw);
+    return loadContentBundle(resolve(process.cwd(), "content/vertical-slice.json"));
 }
 test("content selection is deterministic for same state", async () => {
     const bundle = await loadBundle();
@@ -45,4 +46,48 @@ test("crisis batch selection can return multiple unique packets", async () => {
     });
     const batch = selectCurrentContentBatch(state, bundle);
     assert.equal(batch.length >= 1, true);
+});
+test("legacy bundle and equivalent manifest produce deterministic parity for fixed states", async () => {
+    const legacy = await loadContentBundle(resolve(process.cwd(), "content/vertical-slice.json"));
+    const tempRoot = await mkdtemp(join(tmpdir(), "ttp-content-manifest-"));
+    const packPath = join(tempRoot, "pack.json");
+    const manifestPath = join(tempRoot, "index.json");
+    await writeFile(packPath, JSON.stringify({
+        id: "parity-pack",
+        challenges: legacy.challenges,
+        npcs: legacy.npcs,
+        scenes: legacy.scenes,
+        eventCards: legacy.eventCards,
+        briefings: legacy.briefings
+    }), "utf8");
+    await writeFile(manifestPath, JSON.stringify({
+        version: legacy.version,
+        generatedAt: legacy.generatedAt,
+        packs: ["pack.json"]
+    }), "utf8");
+    const manifestBundle = await loadContentBundle(manifestPath);
+    const states = [
+        createInitialGameState("Y9"),
+        applyEvent(createInitialGameState("Y10"), {
+            type: "RoleChanged",
+            atHour: 0,
+            payload: { role: "pps" }
+        }),
+        applyEvent(applyEvent(createInitialGameState("Y11"), {
+            type: "RoleChanged",
+            atHour: 0,
+            payload: { role: "junior_minister" }
+        }), {
+            type: "TempoChanged",
+            atHour: 0,
+            payload: { tempo: "crisis" }
+        })
+    ];
+    for (const state of states) {
+        const fromLegacy = selectCurrentContent(state, legacy);
+        const fromManifest = selectCurrentContent(state, manifestBundle);
+        assert.equal(fromLegacy.eventCard?.id, fromManifest.eventCard?.id);
+        assert.equal(fromLegacy.challenge?.id, fromManifest.challenge?.id);
+        assert.equal(fromLegacy.scene?.id, fromManifest.scene?.id);
+    }
 });

--- a/dist/tests/content-validation.test.js
+++ b/dist/tests/content-validation.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import test from "node:test";
+import { loadContentBundle } from "../content/loader.js";
 import { validateContentBundle } from "../content/schema.js";
 test("vertical-slice content validates and meets minimum volume", async () => {
     const raw = await readFile(resolve(process.cwd(), "content/vertical-slice.json"), "utf8");
@@ -16,4 +17,14 @@ test("referential integrity check fails on missing challenge reference", async (
     const bundle = JSON.parse(raw);
     bundle.eventCards[0]?.candidateChallengeIds.push("missing_challenge_id");
     assert.throws(() => validateContentBundle(bundle), /missing challenge/i);
+});
+test("manifest content bundle loads and expands PPS/Junior Minister crisis-media card coverage", async () => {
+    const bundle = await loadContentBundle(resolve(process.cwd(), "content/index.json"));
+    validateContentBundle(bundle);
+    assert.equal(bundle.challenges.length >= 32, true);
+    assert.equal(bundle.eventCards.length >= 19, true);
+    assert.equal(bundle.scenes.length >= 12, true);
+    const ppsOrJuniorCards = bundle.eventCards.filter((card) => card.careerLevels.includes("pps") || card.careerLevels.includes("junior_minister"));
+    const crisisMediaCards = ppsOrJuniorCards.filter((card) => card.tempos.includes("crisis") || card.tempos.includes("media_storm"));
+    assert.equal(crisisMediaCards.length >= 13, true);
 });

--- a/src/content/loader.ts
+++ b/src/content/loader.ts
@@ -1,10 +1,75 @@
 import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { validateContentBundle } from "./schema.js";
-import type { ContentBundle } from "./types.js";
+import type { ContentBundle, ContentManifest, ContentPack } from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isManifest(value: unknown): value is ContentManifest {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    typeof value.version === "string" &&
+    typeof value.generatedAt === "string" &&
+    isStringArray(value.packs)
+  );
+}
+
+function assertPack(value: unknown, pathLabel: string): asserts value is ContentPack {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    throw new Error(`Invalid content pack at ${pathLabel}: missing id`);
+  }
+  const arrayKeys = ["challenges", "npcs", "scenes", "eventCards", "briefings"] as const;
+  for (const key of arrayKeys) {
+    if (!Array.isArray(value[key])) {
+      throw new Error(`Invalid content pack at ${pathLabel}: ${key} must be an array`);
+    }
+  }
+}
+
+async function loadManifestBundle(manifest: ContentManifest, manifestPath: string): Promise<ContentBundle> {
+  const manifestDir = dirname(manifestPath);
+  const merged: ContentBundle = {
+    version: manifest.version,
+    generatedAt: manifest.generatedAt,
+    challenges: [],
+    npcs: [],
+    scenes: [],
+    eventCards: [],
+    briefings: []
+  };
+
+  for (const packRef of manifest.packs) {
+    const packPath = resolve(manifestDir, packRef);
+    const rawPack = await readFile(packPath, "utf8");
+    const parsedPack: unknown = JSON.parse(rawPack);
+    assertPack(parsedPack, packRef);
+    merged.challenges.push(...parsedPack.challenges);
+    merged.npcs.push(...parsedPack.npcs);
+    merged.scenes.push(...parsedPack.scenes);
+    merged.eventCards.push(...parsedPack.eventCards);
+    merged.briefings.push(...parsedPack.briefings);
+  }
+
+  validateContentBundle(merged);
+  return merged;
+}
 
 export async function loadContentBundle(filePath: string): Promise<ContentBundle> {
   const raw = await readFile(filePath, "utf8");
   const parsed: unknown = JSON.parse(raw);
+
+  if (isManifest(parsed)) {
+    return loadManifestBundle(parsed, filePath);
+  }
+
   const bundle = parsed as ContentBundle;
   validateContentBundle(bundle);
   return bundle;

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -59,3 +59,19 @@ export interface ContentBundle {
   eventCards: EventCardContent[];
   briefings: BriefingContent[];
 }
+
+export interface ContentPack {
+  id: string;
+  description?: string;
+  challenges: ChallengeContent[];
+  npcs: NPCContent[];
+  scenes: SceneContent[];
+  eventCards: EventCardContent[];
+  briefings: BriefingContent[];
+}
+
+export interface ContentManifest {
+  version: string;
+  generatedAt: string;
+  packs: string[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,8 @@ export type {
   BriefingContent,
   ChallengeContent,
   ContentBundle,
+  ContentManifest,
+  ContentPack,
   EventCardContent,
   NPCContent,
   SceneContent

--- a/src/tests/content-selection.test.ts
+++ b/src/tests/content-selection.test.ts
@@ -1,15 +1,16 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import { applyEvent } from "../domain/reducer.js";
 import { createInitialGameState } from "../domain/state.js";
+import { loadContentBundle } from "../content/loader.js";
 import { selectCurrentContent, selectCurrentContentBatch } from "../content/selection.js";
 import type { ContentBundle } from "../content/types.js";
 
 async function loadBundle(): Promise<ContentBundle> {
-  const raw = await readFile(resolve(process.cwd(), "content/vertical-slice.json"), "utf8");
-  return JSON.parse(raw) as ContentBundle;
+  return loadContentBundle(resolve(process.cwd(), "content/vertical-slice.json"));
 }
 
 test("content selection is deterministic for same state", async () => {
@@ -55,4 +56,56 @@ test("crisis batch selection can return multiple unique packets", async () => {
 
   const batch = selectCurrentContentBatch(state, bundle);
   assert.equal(batch.length >= 1, true);
+});
+
+test("legacy bundle and equivalent manifest produce deterministic parity for fixed states", async () => {
+  const legacy = await loadContentBundle(resolve(process.cwd(), "content/vertical-slice.json"));
+
+  const tempRoot = await mkdtemp(join(tmpdir(), "ttp-content-manifest-"));
+  const packPath = join(tempRoot, "pack.json");
+  const manifestPath = join(tempRoot, "index.json");
+  await writeFile(packPath, JSON.stringify({
+    id: "parity-pack",
+    challenges: legacy.challenges,
+    npcs: legacy.npcs,
+    scenes: legacy.scenes,
+    eventCards: legacy.eventCards,
+    briefings: legacy.briefings
+  }), "utf8");
+  await writeFile(manifestPath, JSON.stringify({
+    version: legacy.version,
+    generatedAt: legacy.generatedAt,
+    packs: ["pack.json"]
+  }), "utf8");
+
+  const manifestBundle = await loadContentBundle(manifestPath);
+
+  const states = [
+    createInitialGameState("Y9"),
+    applyEvent(createInitialGameState("Y10"), {
+      type: "RoleChanged",
+      atHour: 0,
+      payload: { role: "pps" }
+    }),
+    applyEvent(
+      applyEvent(createInitialGameState("Y11"), {
+        type: "RoleChanged",
+        atHour: 0,
+        payload: { role: "junior_minister" }
+      }),
+      {
+        type: "TempoChanged",
+        atHour: 0,
+        payload: { tempo: "crisis" }
+      }
+    )
+  ];
+
+  for (const state of states) {
+    const fromLegacy = selectCurrentContent(state, legacy);
+    const fromManifest = selectCurrentContent(state, manifestBundle);
+    assert.equal(fromLegacy.eventCard?.id, fromManifest.eventCard?.id);
+    assert.equal(fromLegacy.challenge?.id, fromManifest.challenge?.id);
+    assert.equal(fromLegacy.scene?.id, fromManifest.scene?.id);
+  }
 });

--- a/src/tests/content-validation.test.ts
+++ b/src/tests/content-validation.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import test from "node:test";
+import { loadContentBundle } from "../content/loader.js";
 import { validateContentBundle } from "../content/schema.js";
 import type { ContentBundle } from "../content/types.js";
 
@@ -23,4 +24,22 @@ test("referential integrity check fails on missing challenge reference", async (
   bundle.eventCards[0]?.candidateChallengeIds.push("missing_challenge_id");
 
   assert.throws(() => validateContentBundle(bundle), /missing challenge/i);
+});
+
+test("manifest content bundle loads and expands PPS/Junior Minister crisis-media card coverage", async () => {
+  const bundle = await loadContentBundle(resolve(process.cwd(), "content/index.json"));
+
+  validateContentBundle(bundle);
+  assert.equal(bundle.challenges.length >= 32, true);
+  assert.equal(bundle.eventCards.length >= 19, true);
+  assert.equal(bundle.scenes.length >= 12, true);
+
+  const ppsOrJuniorCards = bundle.eventCards.filter((card) =>
+    card.careerLevels.includes("pps") || card.careerLevels.includes("junior_minister")
+  );
+  const crisisMediaCards = ppsOrJuniorCards.filter((card) =>
+    card.tempos.includes("crisis") || card.tempos.includes("media_storm")
+  );
+
+  assert.equal(crisisMediaCards.length >= 13, true);
 });


### PR DESCRIPTION
## Summary
- Deliver Phase 4 strategy lock for content authoring/storage via JSON packs + manifest (`content/index.json`) while preserving legacy `content/vertical-slice.json` compatibility.
- Deliver first Phase 4 content expansion increment focused on PPS + Junior Minister crisis/media routes.
- Add validation/parity tests to protect deterministic content selection during manifest migration.

## Scope
- Content loader/types:
  - `src/content/loader.ts`
  - `src/content/types.ts`
  - `src/index.ts`
- New content assets:
  - `content/index.json`
  - `content/packs/pack-core-vertical-slice.json`
  - `content/packs/pack-phase4-pps-jm-crisis-media.json`
- Tests:
  - `src/tests/content-validation.test.ts`
  - `src/tests/content-selection.test.ts`
- Build tracking:
  - `.build/PHASE4_EXECUTION_MAP.md`
  - `.build/ROADMAP.md`
  - `.build/STATUS.md`
  - `.build/NEXT.md`

## Measured Expansion (legacy baseline -> manifest bundle)
- challenges: `24 -> 32` (`+8`)
- event cards: `13 -> 19` (`+6`)
- scenes: `8 -> 12` (`+4`)
- PPS/JM crisis+media event-card pool: `7 -> 13` (`+6`)

## Validation
- `npm test` passes (`36/36`).
- Added deterministic parity test for equivalent legacy vs manifest bundles.
- Added manifest load + crisis/media coverage assertions.

## Issue Links
- Closes #18
- Closes #19
