### PR TITLE
Phase 4.5: productize retrospective + leaderboard surfaces (#22)

### DIFF
--- a/.build/BACKLOG.md
+++ b/.build/BACKLOG.md
@@ -1,25 +1,23 @@
 ---
 project: "To The Power"
 type: "build"
-lastUpdated: "2026-03-07"
+lastUpdated: "2026-04-02"
 ---
 
 # To The Power — Backlog & Ideas
 
 ## Features / Functionality
 
-- [ ] Role advancement prerequisite gates (loyalty/competence thresholds).
-- [ ] Career ending detection (voted out, sacked, resigned, election defeat, etc.).
-- [ ] Legacy/scoring formula (survival time, peak role, dark index, maths performance).
-- [ ] Leaderboard verification via event-log replay.
+- [ ] Extended ending coverage (voted out, sacked, resigned, election defeat) beyond current baseline states.
 - [ ] NPC dormancy/resurgence trigger model depth.
 
 ## Prototype / UI
 
-- [ ] Minimal browser prototype shell wired to `PrototypeApi`.
-- [ ] Packet-batch interaction flow (view packet -> submit outcome -> apply consequences -> advance).
-- [ ] Session save/load UX for prototype runs.
-- [ ] Debug timeline and event-log view in prototype.
+- [ ] Tier 2 and Tier 3 desk environment implementation once Tier 1 shell is closed.
+- [ ] Moving Day transition pass between major role jumps.
+- [ ] Retrospective dossier polish pass (visual hierarchy, narrative framing, and shareable run view).
+- [ ] Leaderboard comparison presentation across multiple saved runs.
+- [ ] Debug timeline/event-log view strategy after polished shell replaces debug-first defaults.
 
 ## Content
 
@@ -34,16 +32,19 @@ lastUpdated: "2026-03-07"
 - [ ] State invariant tests (`timeHours` monotonic, score bounds, etc.).
 - [ ] Golden snapshot tests for fixed-seed full scenarios.
 - [ ] CI-friendly baseline gate command for regression monitoring.
+- [ ] Tier 1 shell integration test harness for packet/fallout/tempo regressions.
 
 ## Product / Research
 
 - [ ] Final cohort gate targets after 200+ seed sweeps.
 - [ ] Long-term content storage strategy (JSON vs CMS ingest).
-- [ ] Accessibility baseline for prototype and release.
+- [ ] Formal accessibility audit after Tier 1 shell hardening.
 - [ ] Educator dashboard scope for early release.
 
 ## Captured Thoughts
 
 - Core architecture is stable; major leverage is now UI integration and content depth.
-- Cohort gates should remain the primary balancing decision signal.
-- Per-seed outliers are still valuable for targeted scenario diagnostics.
+- Tier 1 shell should be treated as the UX quality bar for all future role tiers.
+- Decorative diegesis is valuable only when primary interaction anchors remain unmistakable.
+- Tempo pressure must escalate stakes, not interaction ambiguity.
+- Near-photoreal (stylised-real) presentation is now a locked direction for Tier 1, not an optional later art pass.

--- a/.build/NEXT.md
+++ b/.build/NEXT.md
@@ -1,23 +1,23 @@
 ---
 project: "To The Power"
 type: "build"
-lastUpdated: "2026-03-12"
+lastUpdated: "2026-04-02"
 ---
 
 # To The Power — Next Steps
 
 ## Immediate (This Session / Week)
 
-1. Start [#23](https://github.com/Oaks3000/to-the-power/issues/23) to formalize playtest loop thresholds and evidence template.
-2. Begin [#20](https://github.com/Oaks3000/to-the-power/issues/20) accessibility baseline hardening gate definition.
-3. Scope [#21](https://github.com/Oaks3000/to-the-power/issues/21) browser regression harness implementation details.
+1. Prepare Phase 4 completion handover packet (status, roadmap, and release-gate evidence links).
+2. Define Phase 5 candidate scope and split blocking vs non-blocking backlog items.
+3. Open and sequence Phase 5 implementation issues.
 
 ## Short Term (Next 2–4 Weeks)
 
-1. Complete [#20](https://github.com/Oaks3000/to-the-power/issues/20) accessibility baseline and hardening gates.
-2. Build [#21](https://github.com/Oaks3000/to-the-power/issues/21) browser regression harness for shell core flow.
-3. Deliver [#22](https://github.com/Oaks3000/to-the-power/issues/22) retrospective/leaderboard productization slice.
-4. Recalculate Phase 4 release gates from playtest and harness results.
+1. Run a full Phase 4 validation sweep (`npm test`, `npm run accessibility:gate`, `npm run prototype:regression`) and archive outputs.
+2. Open Phase 5 issues for Tier 2/Tier 3 shell scaling and deeper ending coverage.
+3. Prioritize backlog items that affect near-term user testing clarity and retention.
+4. Decide migration timing from `vertical-slice.json` default to `content/index.json`.
 
 ## Questions / Unknowns
 

--- a/.build/RETROSPECTIVE_LEADERBOARD_MODEL.md
+++ b/.build/RETROSPECTIVE_LEADERBOARD_MODEL.md
@@ -1,0 +1,54 @@
+# Retrospective + Leaderboard Model (Issue #22)
+
+## Purpose
+- Generate retrospective output directly from live run state and event log.
+- Produce a stable leaderboard/legacy DTO for downstream UI polish.
+- Include replay consistency checks so deterministic integrity is visible per run.
+
+## Source of Truth
+- Builder: `src/application/retrospective.ts`
+- API exposure:
+  - Node service API: `src/application/prototype-api.ts#getRetrospectiveReport`
+  - Browser shell API: `prototype/runtime-api.js#getRetrospectiveReport`
+
+## DTO Shape (v1)
+- `schemaVersion: "retrospective-v1"`
+- `summary`
+  - final/peak role, final tempo, total hours, score snapshot, challenge stats
+  - remediation/timed challenge counters
+- `eventCounts`
+  - count for each domain event type in the run log
+- `legacy`
+  - `score` (0-100), `band` (`fragile|developing|established|dominant`), rationale string
+- `leaderboardEntry`
+  - `modelVersion: "legacy-v1"`
+  - run metadata + score + progression metrics
+- `replay`
+  - `deterministic` boolean
+  - checked fields list
+  - mismatch list (non-empty only on failure)
+
+## Legacy Score Formula (legacy-v1)
+- Weighted composite:
+  - party loyalty 24%
+  - public approval 24%
+  - constituency approval 18%
+  - press relationship 16%
+  - challenge accuracy 18%
+  - dark index penalty -20%
+- Clamped to 0..100 then mapped to band:
+  - `75+ dominant`
+  - `60-74 established`
+  - `40-59 developing`
+  - `<40 fragile`
+
+## Determinism Check
+- Rebuild state from event log and compare key fields:
+  - school year, role, tempo, time, key scores, queue counts, event log length
+- Replay uses reducer path with latent evaluation disabled so event log remains the single source of truth for replays.
+- Failures surface explicit per-field mismatch strings in DTO.
+
+## UI Binding
+- Prototype panel: `Retrospective`
+  - shows run snapshot, legacy score/band, DTO stamp, replay status
+  - files: `prototype/index.html`, `prototype/app.js`, `prototype/styles.css`

--- a/.build/ROADMAP.md
+++ b/.build/ROADMAP.md
@@ -2,7 +2,7 @@
 project: "To The Power"
 type: "build"
 createdAt: "2026-03-03"
-lastUpdated: "2026-03-12"
+lastUpdated: "2026-04-02"
 ---
 
 # To The Power — Roadmap
@@ -52,13 +52,17 @@ A British political career simulation that teaches GCSE mathematics through cons
   - Visual direction lock: near-photoreal (stylised-real) desk presentation is required across all 3.6 slices, with full systemization in 3.6.5.
 
 ### Phase 4: Content Expansion + Release Hardening
-- 4.1 Phase 4 execution map + content strategy lock ⏳ (issue [#18](https://github.com/Oaks3000/to-the-power/issues/18))
-- 4.2 Content expansion: crisis/media + mid-career routes ⏳ (issue [#19](https://github.com/Oaks3000/to-the-power/issues/19))
-- 4.3 Release accessibility baseline + hardening gates ⏳ (issue [#20](https://github.com/Oaks3000/to-the-power/issues/20))
-- 4.4 Browser regression harness for desk shell ⏳ (issue [#21](https://github.com/Oaks3000/to-the-power/issues/21))
-- 4.5 Retrospective and leaderboard productization ⏳ (issue [#22](https://github.com/Oaks3000/to-the-power/issues/22))
-- 4.6 Playtest loop and release threshold framework ⏳ (issue [#23](https://github.com/Oaks3000/to-the-power/issues/23))
+- 4.1 Phase 4 execution map + content strategy lock ✅ (issue [#18](https://github.com/Oaks3000/to-the-power/issues/18))
+- 4.2 Content expansion: crisis/media + mid-career routes ✅ (issue [#19](https://github.com/Oaks3000/to-the-power/issues/19))
+- 4.3 Release accessibility baseline + hardening gates ✅ (issue [#20](https://github.com/Oaks3000/to-the-power/issues/20))
+- 4.4 Browser regression harness for desk shell ✅ (issue [#21](https://github.com/Oaks3000/to-the-power/issues/21))
+- 4.5 Retrospective and leaderboard productization ✅ (issue [#22](https://github.com/Oaks3000/to-the-power/issues/22))
+- 4.6 Playtest loop and release threshold framework ✅ (issue [#23](https://github.com/Oaks3000/to-the-power/issues/23))
 - Execution/dependency map artifact: `.build/PHASE4_EXECUTION_MAP.md`
+- Playtest framework artifact: `.build/PHASE4_PLAYTEST_LOOP_FRAMEWORK.md`
+- Accessibility gates artifact: `.build/ACCESSIBILITY_RELEASE_GATES.md`
+- Browser regression command: `npm run prototype:regression`
+- Retrospective/leaderboard model artifact: `.build/RETROSPECTIVE_LEADERBOARD_MODEL.md`
 
 ## Out of Scope (for now)
 

--- a/.build/STATUS.md
+++ b/.build/STATUS.md
@@ -4,19 +4,19 @@ type: "build"
 priority: 1
 phase: "Phase 4 — Content Expansion + Release Hardening"
 progress: 0
-overallProgressEstimate: 88
-phaseIssueProgress: "2/6"
-lastUpdated: "2026-03-12"
-lastTouched: "2026-03-12"
+overallProgressEstimate: 92
+phaseIssueProgress: "6/6"
+lastUpdated: "2026-04-02"
+lastTouched: "2026-04-02"
 status: "in-progress"
 ---
 
 # To The Power — Current Status
 
 **Phase:** Phase 4 — Content Expansion + Release Hardening
-**Issue-tracked Phase Progress:** 33% (2 closed / 6 tracked issues)
-**Overall Project Progress (estimated):** 88%
-**Last Updated:** 2026-03-12
+**Issue-tracked Phase Progress:** 100% (6 closed / 6 tracked issues)
+**Overall Project Progress (estimated):** 92%
+**Last Updated:** 2026-04-02
 
 ## What's Done
 
@@ -29,18 +29,34 @@ status: "in-progress"
 - Phase 3 issue-tracked tranche is fully closed (12/12).
 - Phase 4 kickoff issue set opened:
   - [#18](https://github.com/Oaks3000/to-the-power/issues/18) ✅
-  - [#19](https://github.com/Oaks3000/to-the-power/issues/19)
-  - [#20](https://github.com/Oaks3000/to-the-power/issues/20)
-  - [#21](https://github.com/Oaks3000/to-the-power/issues/21)
-  - [#22](https://github.com/Oaks3000/to-the-power/issues/22)
-  - [#23](https://github.com/Oaks3000/to-the-power/issues/23)
+  - [#19](https://github.com/Oaks3000/to-the-power/issues/19) ✅
+  - [#20](https://github.com/Oaks3000/to-the-power/issues/20) ✅
+  - [#21](https://github.com/Oaks3000/to-the-power/issues/21) ✅
+  - [#22](https://github.com/Oaks3000/to-the-power/issues/22) ✅
+  - [#23](https://github.com/Oaks3000/to-the-power/issues/23) ✅
 
 ## What's In Progress
 
-- Phase 4 kickoff has started with planning, content expansion, hardening, and automation tracks.
+- Phase 4 execution closeout and handover packaging.
 - #19 implementation complete and closed:
   - PPS/Junior Minister crisis/media pack increment delivered (+8 challenges, +6 event cards, +4 scenes)
   - manifest loading support + parity/volume tests delivered
+- #23 framework draft in branch:
+  - playtest loop framework + run templates added (`.build/PHASE4_PLAYTEST_LOOP_FRAMEWORK.md`)
+  - threshold lock: pragmatic defaults, internal testers first with mixed tester where feasible, weekly cadence after dry run
+  - timed confirmation pass achieved (`01:21`, zero confusion indicators) and issue closed
+- #20 hardening complete and closed:
+  - release accessibility baseline and hard-fail gates documented (`.build/ACCESSIBILITY_RELEASE_GATES.md`)
+  - executable accessibility regression gate added (`npm run accessibility:gate`) and passing
+- #21 regression harness complete and closed:
+  - browser-level prototype regression command added (`npm run prototype:regression`)
+  - deterministic core flow and responsive breakpoint checks now gated with actionable diagnostics
+- #22 retrospective/leaderboard productization complete:
+  - shared model builder added (`src/application/retrospective.ts`)
+  - API surface stabilized in Node + browser runtime (`getRetrospectiveReport`)
+  - shell retrospective panel now renders live state-derived report/legacy summary
+  - replay-consistency check and deterministic tests added
+  - model documentation added (`.build/RETROSPECTIVE_LEADERBOARD_MODEL.md`)
 
 ## Blockers
 
@@ -49,8 +65,8 @@ status: "in-progress"
 ## Issue Tracking Snapshot
 
 - Closed (Phase 3): [#6](https://github.com/Oaks3000/to-the-power/issues/6), [#7](https://github.com/Oaks3000/to-the-power/issues/7), [#8](https://github.com/Oaks3000/to-the-power/issues/8), [#9](https://github.com/Oaks3000/to-the-power/issues/9), [#10](https://github.com/Oaks3000/to-the-power/issues/10), [#11](https://github.com/Oaks3000/to-the-power/issues/11), [#12](https://github.com/Oaks3000/to-the-power/issues/12), [#13](https://github.com/Oaks3000/to-the-power/issues/13), [#14](https://github.com/Oaks3000/to-the-power/issues/14), [#15](https://github.com/Oaks3000/to-the-power/issues/15), [#16](https://github.com/Oaks3000/to-the-power/issues/16), [#17](https://github.com/Oaks3000/to-the-power/issues/17)
-- Closed (Phase 4): [#18](https://github.com/Oaks3000/to-the-power/issues/18), [#19](https://github.com/Oaks3000/to-the-power/issues/19)
-- Open (Phase 4): [#20](https://github.com/Oaks3000/to-the-power/issues/20), [#21](https://github.com/Oaks3000/to-the-power/issues/21), [#22](https://github.com/Oaks3000/to-the-power/issues/22), [#23](https://github.com/Oaks3000/to-the-power/issues/23)
+- Closed (Phase 4): [#18](https://github.com/Oaks3000/to-the-power/issues/18), [#19](https://github.com/Oaks3000/to-the-power/issues/19), [#20](https://github.com/Oaks3000/to-the-power/issues/20), [#21](https://github.com/Oaks3000/to-the-power/issues/21), [#22](https://github.com/Oaks3000/to-the-power/issues/22), [#23](https://github.com/Oaks3000/to-the-power/issues/23)
+- Open (Phase 4): None
 
 ## Notes
 
@@ -62,3 +78,7 @@ status: "in-progress"
 - #13 final acceptance evidence was posted and #13 closed on 2026-03-12.
 - #18 final acceptance evidence was posted and #18 closed on 2026-03-14.
 - #19 final acceptance evidence was posted and #19 closed on 2026-03-14.
+- #23 final acceptance evidence was posted and #23 closed on 2026-04-01.
+- #20 final acceptance evidence was posted and #20 closed on 2026-04-02.
+- #21 final acceptance evidence was posted and #21 closed on 2026-04-02.
+- #22 final acceptance evidence was posted and #22 closed on 2026-04-02.

--- a/dist/application/prototype-api.js
+++ b/dist/application/prototype-api.js
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { GameService } from "./game-service.js";
+import { buildRetrospectiveReport } from "./retrospective.js";
 function mapPacket(selection) {
     const packet = { band: selection.band };
     if (selection.eventCard) {
@@ -99,5 +100,8 @@ export class PrototypeApi {
     }
     getStateSummary() {
         return getStateSummary(this.service.getState());
+    }
+    getRetrospectiveReport(input = {}) {
+        return buildRetrospectiveReport(this.service.getState(), input);
     }
 }

--- a/dist/application/retrospective.js
+++ b/dist/application/retrospective.js
@@ -1,0 +1,196 @@
+import { reduceEvents } from "../domain/reducer.js";
+import { createInitialGameState } from "../domain/state.js";
+const ROLE_ORDER = ["backbencher", "pps", "junior_minister", "minister_of_state", "cabinet", "pm"];
+const EVENT_TYPES = [
+    "SchoolYearSet",
+    "RoleChanged",
+    "TempoChanged",
+    "TimeAdvanced",
+    "ChallengeAttempted",
+    "RemediationTriggered",
+    "TimedChallengeStarted",
+    "TimedChallengeExpired",
+    "LatentConsequenceRegistered",
+    "LatentConsequenceTriggered",
+    "NPCRelationshipChanged",
+    "DarkIndexChanged"
+];
+function clampPercent(value) {
+    return Math.max(0, Math.min(100, value));
+}
+function countEvents(events) {
+    const counts = Object.fromEntries(EVENT_TYPES.map((type) => [type, 0]));
+    for (const event of events) {
+        counts[event.type] += 1;
+    }
+    return counts;
+}
+function findPeakRole(state) {
+    const roleSeen = new Set([state.currentRole]);
+    for (const event of state.eventLog) {
+        if (event.type !== "RoleChanged") {
+            continue;
+        }
+        const role = event.payload.role;
+        if (role === "backbencher" ||
+            role === "pps" ||
+            role === "junior_minister" ||
+            role === "minister_of_state" ||
+            role === "cabinet" ||
+            role === "pm") {
+            roleSeen.add(role);
+        }
+    }
+    let peak = "backbencher";
+    for (const role of ROLE_ORDER) {
+        if (roleSeen.has(role)) {
+            peak = role;
+        }
+    }
+    return peak;
+}
+function computeChallengeStats(events) {
+    let attempts = 0;
+    let correct = 0;
+    const topics = new Set();
+    for (const event of events) {
+        if (event.type !== "ChallengeAttempted") {
+            continue;
+        }
+        attempts += 1;
+        if (event.payload.correct === true) {
+            correct += 1;
+        }
+        const topic = event.payload.topic;
+        if (typeof topic === "string" && topic.length > 0) {
+            topics.add(topic);
+        }
+    }
+    const incorrect = attempts - correct;
+    const accuracy = attempts === 0 ? 0 : Math.round((correct / attempts) * 100);
+    return {
+        attempts,
+        correct,
+        incorrect,
+        accuracy,
+        topicsAttempted: topics.size
+    };
+}
+function computeLegacySummary(state, challengeAccuracy) {
+    const composite = Math.round(state.partyLoyaltyScore * 0.24 +
+        state.publicApproval * 0.24 +
+        state.constituencyApproval * 0.18 +
+        state.pressRelationship * 0.16 +
+        challengeAccuracy * 0.18 -
+        state.darkIndex * 0.2);
+    const score = clampPercent(composite);
+    if (score >= 75) {
+        return {
+            score,
+            band: "dominant",
+            rationale: "Broad approval remained strong while risk pressure stayed contained."
+        };
+    }
+    if (score >= 60) {
+        return {
+            score,
+            band: "established",
+            rationale: "A stable record with more strengths than liabilities."
+        };
+    }
+    if (score >= 40) {
+        return {
+            score,
+            band: "developing",
+            rationale: "Mixed outcomes kept progression viable but not secure."
+        };
+    }
+    return {
+        score,
+        band: "fragile",
+        rationale: "Risk, misses, or weak support outweighed headline progress."
+    };
+}
+function buildReplayConsistency(state, seedState, rng) {
+    const replayed = reduceEvents(seedState, state.eventLog, rng, { evaluateLatent: false });
+    const checkedFields = [
+        "schoolYear",
+        "currentRole",
+        "currentTempo",
+        "timeHours",
+        "partyLoyaltyScore",
+        "publicApproval",
+        "constituencyApproval",
+        "pressRelationship",
+        "darkIndex",
+        "pendingRemediations.length",
+        "activeTimedChallenges.count",
+        "eventLog.length"
+    ];
+    const mismatches = [];
+    const compare = (label, left, right) => {
+        if (left !== right) {
+            mismatches.push(`${label}: expected ${String(left)} got ${String(right)}`);
+        }
+    };
+    compare("schoolYear", state.schoolYear, replayed.schoolYear);
+    compare("currentRole", state.currentRole, replayed.currentRole);
+    compare("currentTempo", state.currentTempo, replayed.currentTempo);
+    compare("timeHours", state.timeHours, replayed.timeHours);
+    compare("partyLoyaltyScore", state.partyLoyaltyScore, replayed.partyLoyaltyScore);
+    compare("publicApproval", state.publicApproval, replayed.publicApproval);
+    compare("constituencyApproval", state.constituencyApproval, replayed.constituencyApproval);
+    compare("pressRelationship", state.pressRelationship, replayed.pressRelationship);
+    compare("darkIndex", state.darkIndex, replayed.darkIndex);
+    compare("pendingRemediations.length", state.pendingRemediations.length, replayed.pendingRemediations.length);
+    compare("activeTimedChallenges.count", Object.keys(state.activeTimedChallenges).length, Object.keys(replayed.activeTimedChallenges).length);
+    compare("eventLog.length", state.eventLog.length, replayed.eventLog.length);
+    return {
+        deterministic: mismatches.length === 0,
+        checkedFields,
+        mismatches
+    };
+}
+export function buildRetrospectiveReport(state, options = {}) {
+    const challengeStats = computeChallengeStats(state.eventLog);
+    const legacy = computeLegacySummary(state, challengeStats.accuracy);
+    const replay = buildReplayConsistency(state, options.seedState ?? createInitialGameState(state.schoolYear), options.rng ?? Math.random);
+    const now = options.now ?? new Date();
+    const peakRole = findPeakRole(state);
+    return {
+        schemaVersion: "retrospective-v1",
+        summary: {
+            schoolYear: state.schoolYear,
+            finalRole: state.currentRole,
+            peakRole,
+            finalTempo: state.currentTempo,
+            totalHours: state.timeHours,
+            finalScores: {
+                partyLoyalty: state.partyLoyaltyScore,
+                publicApproval: state.publicApproval,
+                constituencyApproval: state.constituencyApproval,
+                pressRelationship: state.pressRelationship,
+                darkIndex: state.darkIndex
+            },
+            challengeStats,
+            remediationTriggered: state.eventLog.filter((event) => event.type === "RemediationTriggered").length,
+            activeTimedChallenges: Object.keys(state.activeTimedChallenges).length,
+            pendingRemediations: state.pendingRemediations.length
+        },
+        eventCounts: countEvents(state.eventLog),
+        legacy,
+        leaderboardEntry: {
+            modelVersion: "legacy-v1",
+            runId: options.runId ?? `run-${state.schoolYear}-${state.timeHours}h-${state.eventLog.length}e`,
+            playerAlias: options.playerAlias ?? "desk-shell",
+            legacyScore: legacy.score,
+            peakRole,
+            finalRole: state.currentRole,
+            totalHours: state.timeHours,
+            challengeAccuracy: challengeStats.accuracy,
+            remediationTriggered: state.eventLog.filter((event) => event.type === "RemediationTriggered").length,
+            timestampIso: now.toISOString()
+        },
+        replay
+    };
+}

--- a/dist/tests/prototype-api.test.js
+++ b/dist/tests/prototype-api.test.js
@@ -53,3 +53,20 @@ test("PrototypeApi.create loads content and exposes packet batch", async () => {
     const packets = api.getCurrentPacketBatch();
     assert.equal(packets.length >= 1, true);
 });
+test("PrototypeApi retrospective report exposes stable DTO with deterministic replay flag", async () => {
+    const bundle = await loadContentBundle(resolve(process.cwd(), "content/vertical-slice.json"));
+    const service = new GameService({ schoolYear: "Y10", contentBundle: bundle, rng: makeDeterministicRng(9) });
+    const api = new PrototypeApi(service);
+    api.submitChallengeOutcome({ topic: "ratio_proportion", correct: true, mode: "decision" });
+    api.advanceTime(4);
+    api.submitChallengeOutcome({ topic: "indices", correct: false, mode: "gate" });
+    const report = api.getRetrospectiveReport({ runId: "test-run", playerAlias: "qa" });
+    assert.equal(report.schemaVersion, "retrospective-v1");
+    assert.equal(report.leaderboardEntry.modelVersion, "legacy-v1");
+    assert.equal(report.leaderboardEntry.runId, "test-run");
+    assert.equal(report.leaderboardEntry.playerAlias, "qa");
+    assert.equal(typeof report.legacy.score, "number");
+    assert.equal(typeof report.summary.challengeStats.accuracy, "number");
+    assert.equal(typeof report.eventCounts.ChallengeAttempted, "number");
+    assert.equal(report.replay.deterministic, true);
+});

--- a/dist/tests/retrospective.test.js
+++ b/dist/tests/retrospective.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildRetrospectiveReport } from "../application/retrospective.js";
+import { executeCommand } from "../domain/commands.js";
+import { createInitialGameState } from "../domain/state.js";
+test("retrospective report is deterministic for fixed event log and timestamp", () => {
+    let state = createInitialGameState("Y9");
+    state = executeCommand(state, { type: "change_role", role: "pps" });
+    state = executeCommand(state, { type: "submit_challenge_answer", topic: "percentages", correct: true, mode: "decision" });
+    state = executeCommand(state, { type: "advance_time", hours: 3 });
+    state = executeCommand(state, { type: "submit_challenge_answer", topic: "percentages", correct: false, mode: "crisis" });
+    const fixedNow = new Date("2026-03-31T12:00:00.000Z");
+    const reportA = buildRetrospectiveReport(state, { runId: "det-1", playerAlias: "tester", now: fixedNow });
+    const reportB = buildRetrospectiveReport(state, { runId: "det-1", playerAlias: "tester", now: fixedNow });
+    assert.deepEqual(reportA, reportB);
+    assert.equal(reportA.replay.deterministic, true);
+    assert.equal(reportA.eventCounts.ChallengeAttempted, 2);
+});
+test("legacy score model penalizes dark index escalation", () => {
+    let state = createInitialGameState("Y10");
+    state = executeCommand(state, { type: "submit_challenge_answer", topic: "ratio_proportion", correct: true, mode: "gate" });
+    const baseline = buildRetrospectiveReport(state, { now: new Date("2026-04-01T12:00:00.000Z") });
+    state = executeCommand(state, { type: "change_dark_index", delta: 30 });
+    const escalated = buildRetrospectiveReport(state, { now: new Date("2026-04-01T12:00:00.000Z") });
+    assert.equal(escalated.legacy.score < baseline.legacy.score, true);
+});

--- a/prototype/app.js
+++ b/prototype/app.js
@@ -1,0 +1,1311 @@
+import { PrototypeApi } from "/prototype/runtime-api.js";
+import { validateContentBundle } from "/dist/content/schema.js";
+
+const summaryEntries = [
+  ["School year", "schoolYear"],
+  ["Role", "currentRole"],
+  ["Tempo", "currentTempo"],
+  ["Time", "timeHours"],
+  ["Party loyalty", "partyLoyaltyScore"],
+  ["Public approval", "publicApproval"],
+  ["Constituency", "constituencyApproval"],
+  ["Press", "pressRelationship"],
+  ["Dark index", "darkIndex"],
+  ["Remediations", "pendingRemediations"],
+  ["Timed challenges", "activeTimedChallenges"],
+  ["Event log", "eventLogEntries"]
+];
+
+const elements = {
+  actionResult: document.querySelector("#action-result"),
+  actionType: document.querySelector("#action-type"),
+  advance: document.querySelector("#advance"),
+  advanceHours: document.querySelector("#advance-hours"),
+  bubbleAnchor: document.querySelector("#bubble-anchor"),
+  bubbleLead: document.querySelector("#bubble-lead"),
+  bubbleSurface: document.querySelector("#bubble-surface"),
+  collisionQueue: document.querySelector("#collision-queue"),
+  collisionStamp: document.querySelector("#collision-stamp"),
+  collisionSurface: document.querySelector("#collision-surface"),
+  detailsToggle: document.querySelector("#details-toggle"),
+  nextStep: document.querySelector("#next-step"),
+  audioState: document.querySelector("#audio-state"),
+  audioToggle: document.querySelector("#audio-toggle"),
+  cleanReadToggle: document.querySelector("#clean-read-toggle"),
+  clockReadout: document.querySelector("#clock-readout"),
+  diarySurface: document.querySelector("#diary-surface"),
+  eventCount: document.querySelector("#event-count"),
+  eventLog: document.querySelector("#event-log"),
+  focusOrderStamp: document.querySelector("#focus-order-stamp"),
+  interrupt: document.querySelector("#interrupt"),
+  interruptBody: document.querySelector("#interrupt-body"),
+  interruptDismiss: document.querySelector("#interrupt-dismiss"),
+  interruptReturn: document.querySelector("#interrupt-return"),
+  interruptTitle: document.querySelector("#interrupt-title"),
+  lampAnchor: document.querySelector("#lamp-anchor"),
+  openNext: document.querySelector("#open-next"),
+  packetCount: document.querySelector("#packet-count"),
+  packetFullscreenClose: document.querySelector("#packet-fullscreen-close"),
+  packetFullscreenToggle: document.querySelector("#packet-fullscreen-toggle"),
+  packetFocus: document.querySelector("#packet-focus"),
+  packets: document.querySelector("#packets"),
+  phoneBatches: document.querySelector("#phone-batches"),
+  phoneAnchor: document.querySelector("#phone-anchor"),
+  phoneSurface: document.querySelector("#phone-surface"),
+  progression: document.querySelector("#progression"),
+  promotionStamp: document.querySelector("#promotion-stamp"),
+  retrospectiveStamp: document.querySelector("#retrospective-stamp"),
+  retrospectiveSummary: document.querySelector("#retrospective-summary"),
+  leaderboardSummary: document.querySelector("#leaderboard-summary"),
+  recordAnchor: document.querySelector("#record-anchor"),
+  recordStat: document.querySelector("#record-stat"),
+  recordSurface: document.querySelector("#record-surface"),
+  reducedMotionToggle: document.querySelector("#reduced-motion-toggle"),
+  refresh: document.querySelector("#refresh"),
+  restart: document.querySelector("#restart"),
+  schoolYear: document.querySelector("#school-year"),
+  status: document.querySelector("#status"),
+  summary: document.querySelector("#summary"),
+  summaryStamp: document.querySelector("#summary-stamp"),
+  supplementList: document.querySelector("#supplement-list"),
+  supplementAnchor: document.querySelector("#supplement-anchor"),
+  supplementStamp: document.querySelector("#supplement-stamp"),
+  supplementSurface: document.querySelector("#supplement-surface"),
+  tempoState: document.querySelector("#tempo-state"),
+  trayAnchor: document.querySelector("#tray-anchor"),
+  trayState: document.querySelector("#tray-state")
+};
+
+const SURFACE_FOCUS_ORDER = [
+  "In-Tray",
+  "Active packet",
+  "Smartphone",
+  "The Record",
+  "The Bubble",
+  "The Supplement",
+  "Diary"
+];
+
+const URGENT_TEMPOS = new Set(["crisis", "media_storm"]);
+const TEMPO_PROFILES = {
+  recess: { visibleBatches: 2, updatesPerBatch: 2, audioFrequency: 220, pressureClass: "recess" },
+  parliamentary: { visibleBatches: 3, updatesPerBatch: 3, audioFrequency: 260, pressureClass: "parliamentary" },
+  crisis: { visibleBatches: 5, updatesPerBatch: 4, audioFrequency: 330, pressureClass: "crisis" },
+  media_storm: { visibleBatches: 6, updatesPerBatch: 5, audioFrequency: 390, pressureClass: "media_storm" }
+};
+const COLLISION_PRIORITY = {
+  crisis_interrupt: 1,
+  timed_challenge: 2,
+  packet_resolution: 3,
+  fallout_updates: 4,
+  flavour_updates: 5
+};
+
+let api;
+let currentPackets = [];
+let activePacketIndex = -1;
+let lastAction = null;
+let dismissedInterruptKey = null;
+let latestSummary = null;
+let packetFullscreen = false;
+let falloutBatchCounter = 0;
+let smartphoneBatches = [];
+let recordLens = null;
+let bubbleShadowLead = null;
+let supplementItems = [];
+let collisionQueueItems = [];
+let audioEnabled = false;
+let audioContext = null;
+let lastTempoForCue = null;
+let lastCollisionCueKey = "";
+let cleanReadEnabled = false;
+let reducedMotionEnabled = false;
+let detailsVisible = false;
+
+function setStatus(message) {
+  elements.status.textContent = message;
+}
+
+function applyDetailsVisibility() {
+  document.body.classList.toggle("details-expanded", detailsVisible);
+  if (elements.detailsToggle) {
+    elements.detailsToggle.textContent = detailsVisible ? "Hide extra panels" : "Show extra panels";
+  }
+}
+
+function updateNextStep(trayState) {
+  if (!elements.nextStep) {
+    return;
+  }
+  if (currentPackets.length === 0) {
+    elements.nextStep.textContent = "No tasks are ready. Press Refresh batch to load a new task.";
+    return;
+  }
+  if (activePacketIndex < 0) {
+    elements.nextStep.textContent = "Press Open next task to bring a task into view.";
+    return;
+  }
+  if (lastAction?.kind === "challenge") {
+    elements.nextStep.textContent = "Good. Press Open next task to continue.";
+    return;
+  }
+  if (trayState === "urgent") {
+    elements.nextStep.textContent = "Urgent task: answer the question in Active Packet now.";
+    return;
+  }
+  elements.nextStep.textContent = "Read the question, type a number, then press Check answer.";
+}
+
+function formatTempo(tempo) {
+  return String(tempo).replaceAll("_", " ");
+}
+
+function computeTrayState(summary, packets) {
+  if (packets.length === 0) {
+    return "idle";
+  }
+  const hasTimedPacket = packets.some((packet) => Boolean(packet.challenge?.timed));
+  if (URGENT_TEMPOS.has(summary.currentTempo) || hasTimedPacket) {
+    return "urgent";
+  }
+  return "available";
+}
+
+function isNarrowViewport() {
+  return window.matchMedia("(max-width: 820px)").matches;
+}
+
+function setPacketFullscreen(nextState) {
+  packetFullscreen = nextState;
+  document.body.classList.toggle("packet-fullscreen", packetFullscreen);
+  elements.packetFullscreenClose.classList.toggle("hidden", !packetFullscreen);
+  elements.packetFullscreenToggle.classList.toggle("hidden", packetFullscreen);
+}
+
+function applyAccessibilityModes() {
+  document.body.classList.toggle("clean-read", cleanReadEnabled);
+  document.body.classList.toggle("reduced-motion", reducedMotionEnabled);
+  if (elements.cleanReadToggle) {
+    elements.cleanReadToggle.checked = cleanReadEnabled;
+  }
+  if (elements.reducedMotionToggle) {
+    elements.reducedMotionToggle.checked = reducedMotionEnabled;
+  }
+}
+
+function persistAccessibilityModes() {
+  try {
+    localStorage.setItem("ttp.cleanRead", cleanReadEnabled ? "1" : "0");
+    localStorage.setItem("ttp.reducedMotion", reducedMotionEnabled ? "1" : "0");
+  } catch {
+    // Ignore persistence failures; runtime mode still applies.
+  }
+}
+
+function loadAccessibilityModes() {
+  try {
+    cleanReadEnabled = localStorage.getItem("ttp.cleanRead") === "1";
+    reducedMotionEnabled = localStorage.getItem("ttp.reducedMotion") === "1";
+  } catch {
+    cleanReadEnabled = false;
+    reducedMotionEnabled = false;
+  }
+  applyAccessibilityModes();
+}
+
+function getTempoProfile(tempo) {
+  return TEMPO_PROFILES[tempo] ?? TEMPO_PROFILES.parliamentary;
+}
+
+function setTempoVisualState(tempo) {
+  const tempoClasses = Object.keys(TEMPO_PROFILES).map((entry) => `tempo-${entry}`);
+  document.body.classList.remove(...tempoClasses);
+  document.body.classList.add(`tempo-${tempo}`);
+  elements.tempoState.textContent = `${formatTempo(tempo)} pressure`;
+}
+
+function ensureAudioContext() {
+  if (audioContext) {
+    return audioContext;
+  }
+  const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContextCtor) {
+    return null;
+  }
+  audioContext = new AudioContextCtor();
+  return audioContext;
+}
+
+function playPressureCue(summary, reasonKey) {
+  const profile = getTempoProfile(summary.currentTempo);
+  const cueLabel = `${formatTempo(summary.currentTempo)} hint`;
+  const fallbackLabel = "Sound is off. Visual urgency hint is active.";
+
+  if (!audioEnabled) {
+    elements.audioState.textContent = fallbackLabel;
+    return;
+  }
+
+  const ctx = ensureAudioContext();
+  if (!ctx) {
+    elements.audioState.textContent = "Sound unavailable. Visual urgency hint is active.";
+    return;
+  }
+  if (ctx.state === "suspended") {
+    ctx.resume().catch(() => {});
+  }
+
+  const now = ctx.currentTime;
+  const oscA = ctx.createOscillator();
+  const gainA = ctx.createGain();
+  oscA.type = "sine";
+  oscA.frequency.value = profile.audioFrequency;
+  gainA.gain.value = 0.0001;
+  gainA.gain.exponentialRampToValueAtTime(0.04, now + 0.03);
+  gainA.gain.exponentialRampToValueAtTime(0.0001, now + 0.22);
+  oscA.connect(gainA);
+  gainA.connect(ctx.destination);
+  oscA.start(now);
+  oscA.stop(now + 0.24);
+
+  if (summary.currentTempo === "crisis" || summary.currentTempo === "media_storm") {
+    const oscB = ctx.createOscillator();
+    const gainB = ctx.createGain();
+    oscB.type = "triangle";
+    oscB.frequency.value = profile.audioFrequency * 1.22;
+    gainB.gain.value = 0.0001;
+    gainB.gain.exponentialRampToValueAtTime(0.03, now + 0.19);
+    gainB.gain.exponentialRampToValueAtTime(0.0001, now + 0.37);
+    oscB.connect(gainB);
+    gainB.connect(ctx.destination);
+    oscB.start(now + 0.16);
+    oscB.stop(now + 0.39);
+  }
+
+  elements.audioState.textContent = `${cueLabel} played.`;
+}
+
+function signedDelta(value) {
+  if (value === 0) {
+    return "0";
+  }
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function extractSummaryDeltas(beforeSummary, afterSummary) {
+  return {
+    partyLoyaltyScore: afterSummary.partyLoyaltyScore - beforeSummary.partyLoyaltyScore,
+    publicApproval: afterSummary.publicApproval - beforeSummary.publicApproval,
+    constituencyApproval: afterSummary.constituencyApproval - beforeSummary.constituencyApproval,
+    pressRelationship: afterSummary.pressRelationship - beforeSummary.pressRelationship,
+    darkIndex: afterSummary.darkIndex - beforeSummary.darkIndex,
+    pendingRemediations: afterSummary.pendingRemediations - beforeSummary.pendingRemediations
+  };
+}
+
+function getDominantRecordMetric(deltas, summary) {
+  const metricTable = [
+    { key: "publicApproval", label: "Public approval", value: summary.publicApproval, delta: deltas.publicApproval },
+    { key: "pressRelationship", label: "Press relationship", value: summary.pressRelationship, delta: deltas.pressRelationship },
+    { key: "partyLoyaltyScore", label: "Party loyalty", value: summary.partyLoyaltyScore, delta: deltas.partyLoyaltyScore },
+    { key: "constituencyApproval", label: "Constituency approval", value: summary.constituencyApproval, delta: deltas.constituencyApproval },
+    { key: "darkIndex", label: "Dark index", value: summary.darkIndex, delta: deltas.darkIndex }
+  ];
+
+  metricTable.sort((left, right) => Math.abs(right.delta) - Math.abs(left.delta));
+  return metricTable[0];
+}
+
+function buildShadowLead(deltas, warnings, events) {
+  if (deltas.darkIndex > 0 || warnings.length > 0) {
+    return {
+      headline: "Lobby whispers darken around the office",
+      angle: "Sources suggest consequences are accumulating faster than statements can contain.",
+      confidence: "high"
+    };
+  }
+  if (deltas.publicApproval < 0 || deltas.pressRelationship < 0) {
+    return {
+      headline: "Narrative temperature turns against your brief",
+      angle: "Media desks and constituency chatter are converging on the same criticism pattern.",
+      confidence: Math.abs(deltas.publicApproval) + Math.abs(deltas.pressRelationship) >= 4 ? "high" : "medium"
+    };
+  }
+  if (deltas.publicApproval > 0 || deltas.partyLoyaltyScore > 0) {
+    return {
+      headline: "Backbench buzz tilts in your favour",
+      angle: "Supportive voices are amplifying the latest decision as proof of control.",
+      confidence: "medium"
+    };
+  }
+  if (events.length > 0) {
+    return {
+      headline: "Narrative churn continues without clear winner",
+      angle: "Commentariat tone remains volatile, awaiting the next packet response.",
+      confidence: "low"
+    };
+  }
+  return {
+    headline: "Quiet cycle",
+    angle: "No strong shadow lead has emerged from this step.",
+    confidence: "low"
+  };
+}
+
+function buildSupplementItems(action, deltas) {
+  const items = [];
+  if (action.kind === "challenge" && action.correct === false) {
+    items.push(`Practice brief: revisit ${action.topic} with one reinforcement problem.`);
+  }
+  if (deltas.pendingRemediations > 0) {
+    items.push(`Supplement pack: ${deltas.pendingRemediations} remediation task(s) queued.`);
+  }
+  if (action.response.events.some((event) => event.type === "TimedChallengeStarted")) {
+    items.push("Tempo drill: short timed warm-up to reduce crisis-response latency.");
+  }
+  return items.slice(0, 3);
+}
+
+function buildSmartphoneBatch(action, summary, deltas, isUrgent) {
+  const profile = getTempoProfile(summary.currentTempo);
+  const updates = [];
+
+  if (action.response.warnings.length > 0) {
+    updates.push(...action.response.warnings.map((warning) => `warning:${warning.code}`));
+  }
+
+  if (deltas.publicApproval !== 0) {
+    updates.push(`public approval ${signedDelta(deltas.publicApproval)}`);
+  }
+  if (deltas.pressRelationship !== 0) {
+    updates.push(`press relationship ${signedDelta(deltas.pressRelationship)}`);
+  }
+  if (deltas.darkIndex !== 0) {
+    updates.push(`dark index ${signedDelta(deltas.darkIndex)}`);
+  }
+  if (updates.length === 0 && action.response.events.length > 0) {
+    updates.push(`events:${action.response.events.length} routed`);
+  }
+  if (updates.length === 0) {
+    updates.push("no measurable fallout movement");
+  }
+
+  falloutBatchCounter += 1;
+  return {
+    id: `batch-${falloutBatchCounter}`,
+    label: action.label,
+    urgent: isUrgent,
+    tempo: summary.currentTempo,
+    severity: isUrgent
+      ? (summary.currentTempo === "media_storm" ? "critical" : "high")
+      : (summary.currentTempo === "parliamentary" ? "elevated" : "normal"),
+    updates: updates.slice(0, profile.updatesPerBatch)
+  };
+}
+
+function applyFalloutRouting(action) {
+  const deltas = extractSummaryDeltas(action.beforeSummary, action.response.summary);
+  const summary = action.response.summary;
+  const isUrgent = action.response.warnings.length > 0
+    || URGENT_TEMPOS.has(summary.currentTempo)
+    || deltas.darkIndex >= 2
+    || deltas.publicApproval <= -3
+    || deltas.pressRelationship <= -3;
+
+  const batch = buildSmartphoneBatch(action, summary, deltas, isUrgent);
+  smartphoneBatches = [batch, ...smartphoneBatches].slice(0, 6);
+
+  const metric = getDominantRecordMetric(deltas, summary);
+  recordLens = {
+    label: metric.label,
+    value: metric.value,
+    delta: signedDelta(metric.delta),
+    updatedAt: `${formatTempo(summary.currentTempo)} ${summary.timeHours}h`
+  };
+
+  bubbleShadowLead = buildShadowLead(deltas, action.response.warnings, action.response.events);
+  supplementItems = buildSupplementItems(action, deltas);
+
+  elements.phoneSurface.classList.toggle("urgent-physical", isUrgent);
+}
+
+function buildCollisionQueue(summary, trayState) {
+  const items = [];
+  const hasTimedPacket = currentPackets.some((packet) => Boolean(packet.challenge?.timed));
+  const latestBatch = smartphoneBatches[0];
+
+  if (URGENT_TEMPOS.has(summary.currentTempo)) {
+    items.push({
+      type: "crisis_interrupt",
+      title: "Crisis interruption",
+      detail: `${formatTempo(summary.currentTempo)} demands immediate prioritisation.`,
+      priority: COLLISION_PRIORITY.crisis_interrupt
+    });
+  }
+
+  if (hasTimedPacket) {
+    items.push({
+      type: "timed_challenge",
+      title: "Timed challenge pressure",
+      detail: "Active packet contains timed challenge constraints.",
+      priority: COLLISION_PRIORITY.timed_challenge
+    });
+  }
+
+  if (lastAction?.response?.events?.length > 0) {
+    items.push({
+      type: "packet_resolution",
+      title: "Packet resolution updates",
+      detail: `${lastAction.response.events.length} event(s) emitted from latest action.`,
+      priority: COLLISION_PRIORITY.packet_resolution
+    });
+  }
+
+  if (latestBatch) {
+    items.push({
+      type: "fallout_updates",
+      title: "Fallout surface updates",
+      detail: `${latestBatch.updates.length} routed update(s) in smartphone batch.`,
+      priority: COLLISION_PRIORITY.fallout_updates
+    });
+  }
+
+  if (bubbleShadowLead) {
+    items.push({
+      type: "flavour_updates",
+      title: "Narrative climate lead",
+      detail: bubbleShadowLead.headline,
+      priority: COLLISION_PRIORITY.flavour_updates
+    });
+  }
+
+  if (trayState === "urgent" && !items.some((item) => item.type === "timed_challenge")) {
+    items.push({
+      type: "timed_challenge",
+      title: "Urgent tray state",
+      detail: "In-Tray is signalling urgent packet handling.",
+      priority: COLLISION_PRIORITY.timed_challenge
+    });
+  }
+
+  items.sort((left, right) => left.priority - right.priority);
+  return items.slice(0, 5);
+}
+
+function renderCollisionQueue() {
+  if (collisionQueueItems.length === 0) {
+    elements.collisionQueue.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "No queue pressure." })
+    );
+    elements.collisionStamp.textContent = "priority order";
+    return;
+  }
+
+  elements.collisionQueue.replaceChildren(
+    ...collisionQueueItems.map((item) => {
+      const card = document.createElement("article");
+      card.className = `collision-item priority-${item.priority}`;
+
+      const title = document.createElement("h3");
+      title.textContent = `${item.priority}. ${item.title}`;
+
+      const detail = document.createElement("p");
+      detail.textContent = item.detail;
+
+      card.append(title, detail);
+      return card;
+    })
+  );
+  elements.collisionStamp.textContent = `top: ${collisionQueueItems[0].title}`;
+}
+
+function renderFalloutSurfaces() {
+  const profile = getTempoProfile(latestSummary?.currentTempo ?? "parliamentary");
+  const visibleBatches = smartphoneBatches.slice(0, profile.visibleBatches);
+
+  if (smartphoneBatches.length === 0) {
+    elements.phoneBatches.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "No fallout updates queued yet." })
+    );
+  } else {
+    elements.phoneBatches.replaceChildren(
+      ...visibleBatches.map((batch) => {
+        const article = document.createElement("article");
+        article.className = `phone-batch${batch.urgent ? " urgent" : ""} severity-${batch.severity}`;
+
+        const title = document.createElement("h3");
+        title.textContent = `${batch.label} | ${formatTempo(batch.tempo)}`;
+
+        const list = document.createElement("ul");
+        batch.updates.forEach((update) => {
+          const item = document.createElement("li");
+          item.textContent = update;
+          list.append(item);
+        });
+
+        article.append(title, list);
+        return article;
+      })
+    );
+  }
+
+  if (!recordLens) {
+    elements.recordStat.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        className: "meta",
+        textContent: "Record lens"
+      }),
+      Object.assign(document.createElement("p"), {
+        textContent: "No major state movement recorded yet."
+      })
+    );
+  } else {
+    const kicker = document.createElement("p");
+    kicker.className = "meta";
+    kicker.textContent = `Record lens | ${recordLens.updatedAt}`;
+
+    const value = document.createElement("p");
+    value.textContent = `${recordLens.label}: ${recordLens.value} (${recordLens.delta})`;
+    value.className = "record-value";
+
+    elements.recordStat.replaceChildren(kicker, value);
+  }
+
+  if (!bubbleShadowLead) {
+    elements.bubbleLead.replaceChildren(
+      Object.assign(document.createElement("h3"), { textContent: "Shadow lead" }),
+      Object.assign(document.createElement("p"), { textContent: "No narrative lead is active yet." })
+    );
+  } else {
+    const headline = document.createElement("h3");
+    headline.textContent = bubbleShadowLead.headline;
+
+    const angle = document.createElement("p");
+    angle.textContent = bubbleShadowLead.angle;
+
+    const confidence = document.createElement("p");
+    confidence.className = "meta";
+    confidence.textContent = `confidence: ${bubbleShadowLead.confidence}`;
+
+    elements.bubbleLead.replaceChildren(headline, angle, confidence);
+  }
+
+  if (supplementItems.length === 0) {
+    elements.supplementList.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "No supplementary items queued." })
+    );
+    elements.supplementStamp.textContent = "optional";
+  } else {
+    const list = document.createElement("ul");
+    supplementItems.forEach((itemText) => {
+      const item = document.createElement("li");
+      item.textContent = itemText;
+      list.append(item);
+    });
+    elements.supplementList.replaceChildren(list);
+    elements.supplementStamp.textContent = `${supplementItems.length} queued`;
+  }
+}
+
+function renderSummary(summary) {
+  elements.summary.replaceChildren(
+    ...summaryEntries.flatMap(([label, key]) => {
+      const dt = document.createElement("dt");
+      dt.textContent = label;
+
+      const dd = document.createElement("dd");
+      dd.textContent = String(summary[key]);
+
+      return [dt, dd];
+    })
+  );
+
+  elements.summaryStamp.textContent = `${formatTempo(summary.currentTempo)} at ${summary.timeHours}h`;
+  elements.clockReadout.textContent = `${formatTempo(summary.currentTempo)} | ${summary.timeHours}h`;
+}
+
+function renderProgression(snapshot) {
+  const promotionCard = document.createElement("article");
+  promotionCard.className = "progression-card";
+
+  const promotionHeading = document.createElement("h3");
+  promotionHeading.textContent = snapshot.promotion.nextRole
+    ? `${snapshot.promotion.currentRole} -> ${snapshot.promotion.nextRole}`
+    : `${snapshot.promotion.currentRole} is the current ceiling`;
+
+  const promotionBody = document.createElement("p");
+  promotionBody.textContent = snapshot.promotion.nextRole
+    ? snapshot.promotion.ready
+      ? "Promotion gate is currently satisfied."
+      : "Promotion gate is not yet satisfied."
+    : "No further automatic promotion gate is defined yet.";
+
+  promotionCard.append(promotionHeading, promotionBody);
+
+  if (snapshot.promotion.requirements.length > 0) {
+    const list = document.createElement("ul");
+    snapshot.promotion.requirements.forEach((requirement) => {
+      const item = document.createElement("li");
+      item.textContent = `${requirement.met ? "met" : "open"}: ${requirement.label} ${requirement.current}/${requirement.target}`;
+      list.append(item);
+    });
+    promotionCard.append(list);
+  }
+
+  const careerCard = document.createElement("article");
+  careerCard.className = "progression-card";
+
+  const careerHeading = document.createElement("h3");
+  careerHeading.textContent = snapshot.career.title;
+
+  const careerBody = document.createElement("p");
+  careerBody.textContent = snapshot.career.detail;
+
+  careerCard.append(careerHeading, careerBody);
+
+  elements.progression.replaceChildren(promotionCard, careerCard);
+  elements.promotionStamp.textContent = snapshot.career.kind;
+}
+
+function renderRetrospective(report) {
+  const summary = report.summary;
+  const legacy = report.legacy;
+
+  const summaryCard = document.createElement("article");
+  summaryCard.className = "retrospective-card";
+
+  const title = document.createElement("h3");
+  title.textContent = `${summary.finalRole.replaceAll("_", " ")} finish (${summary.schoolYear})`;
+
+  const detail = document.createElement("p");
+  detail.textContent = `Peak role: ${summary.peakRole.replaceAll("_", " ")}. ${summary.challengeStats.accuracy}% challenge accuracy over ${summary.challengeStats.attempts} attempt${summary.challengeStats.attempts === 1 ? "" : "s"}.`;
+
+  const replay = document.createElement("p");
+  replay.className = "meta";
+  replay.textContent = report.replay.deterministic
+    ? "Replay consistency check: deterministic"
+    : "Replay consistency check: mismatch detected";
+
+  summaryCard.append(title, detail, replay);
+  elements.retrospectiveSummary.replaceChildren(summaryCard);
+
+  const leaderboardCard = document.createElement("article");
+  leaderboardCard.className = "retrospective-card";
+
+  const legacyHeadline = document.createElement("h3");
+  legacyHeadline.textContent = `Legacy score ${legacy.score} (${legacy.band})`;
+
+  const legacyDetail = document.createElement("p");
+  legacyDetail.textContent = legacy.rationale;
+
+  const dtoStamp = document.createElement("p");
+  dtoStamp.className = "meta";
+  dtoStamp.textContent = `DTO ${report.schemaVersion} | ${report.leaderboardEntry.modelVersion} | ${report.leaderboardEntry.runId}`;
+
+  leaderboardCard.append(legacyHeadline, legacyDetail, dtoStamp);
+  elements.leaderboardSummary.replaceChildren(leaderboardCard);
+  elements.retrospectiveStamp.textContent = report.replay.deterministic ? "deterministic replay" : "replay mismatch";
+}
+
+function buildSection(title, body, meta) {
+  const section = document.createElement("section");
+  section.className = "packet-section";
+
+  const heading = document.createElement("h3");
+  heading.textContent = title;
+
+  const text = document.createElement("p");
+  text.textContent = body;
+
+  section.append(heading, text);
+
+  if (meta) {
+    const detail = document.createElement("p");
+    detail.textContent = meta;
+    section.append(detail);
+  }
+
+  return section;
+}
+
+function renderActionResult() {
+  if (!lastAction) {
+    elements.actionType.textContent = "none yet";
+    elements.actionResult.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "No challenge outcome or time advance has been submitted yet."
+      })
+    );
+    elements.eventCount.textContent = "0 emitted";
+    elements.eventLog.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "No events emitted yet."
+      })
+    );
+    return;
+  }
+
+  elements.actionType.textContent = lastAction.label;
+
+  const actionCard = document.createElement("article");
+  actionCard.className = "action-card";
+
+  const heading = document.createElement("h3");
+  heading.textContent = lastAction.heading;
+
+  const summary = document.createElement("p");
+  summary.textContent = `${formatTempo(lastAction.response.summary.currentTempo)} at ${lastAction.response.summary.timeHours}h after ${lastAction.response.events.length} event${lastAction.response.events.length === 1 ? "" : "s"}.`;
+
+  actionCard.append(heading, summary);
+
+  if (lastAction.response.warnings.length > 0) {
+    const warnings = document.createElement("p");
+    warnings.textContent = `Warnings: ${lastAction.response.warnings.map((warning) => warning.code).join(", ")}`;
+    actionCard.append(warnings);
+  }
+
+  elements.actionResult.replaceChildren(actionCard);
+
+  elements.eventCount.textContent = `${lastAction.response.events.length} emitted`;
+  if (lastAction.response.events.length === 0) {
+    elements.eventLog.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "Action emitted no events." })
+    );
+    return;
+  }
+
+  elements.eventLog.replaceChildren(
+    ...lastAction.response.events.map((event, index) => {
+      const card = document.createElement("article");
+      card.className = "event-item";
+
+      const title = document.createElement("h3");
+      title.textContent = `${index + 1}. Event`;
+
+      const body = document.createElement("p");
+      body.textContent = `${event.type} at ${event.atHour}h.`;
+
+      card.append(title, body);
+      return card;
+    })
+  );
+}
+
+function handleChallengeOutcome(packet, correct, numericAnswer) {
+  if (!packet.challenge || !api) {
+    return;
+  }
+
+  const beforeSummary = api.getStateSummary();
+  const answerSnippet = typeof numericAnswer === "string" && numericAnswer.trim() !== ""
+    ? ` with answer ${numericAnswer.trim()}`
+    : "";
+  lastAction = {
+    kind: "challenge",
+    topic: packet.challenge.topic,
+    correct,
+    beforeSummary,
+    label: correct ? "challenge correct" : "challenge incorrect",
+    heading: `${packet.challenge.topic} marked ${correct ? "correct" : "incorrect"}${answerSnippet}`,
+    response: api.submitChallengeOutcome({
+      topic: packet.challenge.topic,
+      correct,
+      mode: packet.challenge.mode
+    })
+  };
+  applyFalloutRouting(lastAction);
+  refreshPackets();
+  setStatus(correct ? "Nice. Answer checked as correct." : "Answer checked as incorrect. Try the next task.");
+}
+
+function handleAdvanceTime() {
+  if (!api) {
+    return;
+  }
+
+  const beforeSummary = api.getStateSummary();
+  const hours = Number.parseInt(elements.advanceHours.value, 10);
+  if (!Number.isInteger(hours) || hours <= 0) {
+    setStatus("Please enter a whole number greater than zero.");
+    return;
+  }
+
+  lastAction = {
+    kind: "time",
+    beforeSummary,
+    label: "advance time",
+    heading: `Advanced simulation by ${hours}h`,
+    response: api.advanceTime(hours)
+  };
+  applyFalloutRouting(lastAction);
+  refreshPackets();
+}
+
+function renderTrayState(state, packetCount) {
+  elements.trayState.textContent = state;
+  elements.packetCount.textContent = `${packetCount} packet${packetCount === 1 ? "" : "s"} in queue`;
+  elements.openNext.disabled = packetCount === 0;
+  elements.trayAnchor.setAttribute(
+    "aria-label",
+    `In-Tray ${state}. ${packetCount} packet${packetCount === 1 ? "" : "s"} available.`
+  );
+}
+
+function renderPacket(packet, index) {
+  const article = document.createElement("article");
+  article.className = "packet";
+  const isCrisisVariant = Boolean(packet.challenge?.timed) || Boolean(latestSummary && URGENT_TEMPOS.has(latestSummary.currentTempo));
+  if (isCrisisVariant) {
+    article.classList.add("packet-crisis");
+  }
+
+  const kicker = document.createElement("p");
+  kicker.className = "doc-kicker";
+  kicker.textContent = isCrisisVariant ? "Crisis packet" : "Event/Decision brief";
+  article.append(kicker);
+
+  const header = document.createElement("div");
+  header.className = "packet-header";
+
+  const title = document.createElement("h3");
+  title.textContent = packet.eventCard?.title ?? `Packet ${index + 1}`;
+
+  const badge = document.createElement("span");
+  badge.className = "badge";
+  badge.textContent = packet.band;
+
+  header.append(title, badge);
+  article.append(header);
+
+  article.append(buildSection("Briefing", packet.eventCard?.description ?? "No event card supplied for this packet."));
+
+  if (packet.challenge) {
+    const timer = packet.challenge.timed && packet.challenge.timerSeconds
+      ? `Timed: ${packet.challenge.timerSeconds}s`
+      : `Mode: ${packet.challenge.mode}`;
+    article.append(buildSection("Decision task", packet.challenge.prompt, `${packet.challenge.topic} | ${timer}`));
+
+    const form = document.createElement("form");
+    form.className = "challenge-form";
+    form.setAttribute("aria-label", `Challenge response for ${packet.challenge.topic}`);
+
+    const answerLabel = document.createElement("label");
+    answerLabel.textContent = "Numeric answer";
+
+    const answerInput = document.createElement("input");
+    answerInput.type = "number";
+    answerInput.step = "any";
+    answerInput.inputMode = "decimal";
+    answerInput.required = true;
+    answerInput.placeholder = "Enter value";
+    answerInput.setAttribute("aria-label", "Numeric answer input");
+    answerLabel.append(answerInput);
+
+    const helper = document.createElement("p");
+    helper.className = "challenge-help";
+    helper.textContent = "Type your number and press Check answer.";
+
+    const actions = document.createElement("div");
+    actions.className = "packet-actions";
+
+    const submitAnswer = document.createElement("button");
+    submitAnswer.type = "submit";
+    submitAnswer.textContent = "Check answer";
+
+    actions.append(submitAnswer);
+    form.append(answerLabel, helper, actions);
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      if (!answerInput.reportValidity()) {
+        return;
+      }
+      const entered = Number(answerInput.value);
+      const expected = packet.challenge.expectedAnswer;
+      const tolerance = packet.challenge.tolerance ?? 0;
+      const correct = typeof expected === "number"
+        ? Math.abs(entered - expected) <= tolerance
+        : true;
+      handleChallengeOutcome(packet, correct, answerInput.value);
+    });
+    article.append(form);
+  }
+
+  if (packet.scene) {
+    const sceneSection = document.createElement("section");
+    sceneSection.className = "scene-attachment";
+
+    const sceneHeading = document.createElement("h4");
+    sceneHeading.textContent = "Attached scene memo";
+
+    const sceneBody = document.createElement("p");
+    sceneBody.textContent = packet.scene.text;
+
+    const sceneMeta = document.createElement("p");
+    sceneMeta.className = "meta";
+    sceneMeta.textContent = `NPC: ${packet.scene.npcId}`;
+
+    sceneSection.append(sceneHeading, sceneBody, sceneMeta);
+    article.append(sceneSection);
+  }
+
+  return article;
+}
+
+function renderPacketFocus() {
+  if (activePacketIndex < 0 || !currentPackets[activePacketIndex]) {
+    elements.packetFullscreenToggle.disabled = true;
+    elements.packetFocus.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "No active packet selected. Open the tray to pull the next packet into focus."
+      })
+    );
+    elements.packetFocus.removeAttribute("aria-label");
+    return;
+  }
+
+  elements.packetFullscreenToggle.disabled = false;
+  const packet = currentPackets[activePacketIndex];
+  elements.packetFocus.setAttribute(
+    "aria-label",
+    `Active packet ${activePacketIndex + 1}: ${packet.eventCard?.title ?? "Untitled packet"}`
+  );
+  elements.packetFocus.replaceChildren(renderPacket(packet, activePacketIndex));
+}
+
+function setActivePacket(index) {
+  if (index < 0 || index >= currentPackets.length) {
+    activePacketIndex = -1;
+    renderPacketFocus();
+    return;
+  }
+
+  activePacketIndex = index;
+  renderPacketFocus();
+  renderPacketQueue();
+  elements.packetFocus.focus({ preventScroll: true });
+}
+
+function renderPacketQueue() {
+  if (currentPackets.length === 0) {
+    elements.packets.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "Tray is clear. Advance time or refresh to continue."
+      })
+    );
+    return;
+  }
+
+  elements.packets.replaceChildren(
+    ...currentPackets.map((packet, index) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `queue-item${index === activePacketIndex ? " active" : ""}`;
+      button.textContent = packet.eventCard?.title ?? `Packet ${index + 1}`;
+      button.addEventListener("click", () => {
+        setActivePacket(index);
+      });
+      return button;
+    })
+  );
+}
+
+function openNextPacketFromTray() {
+  if (currentPackets.length === 0) {
+    setStatus("In-Tray is idle. No packet available to open.");
+    return;
+  }
+
+  const nextIndex = activePacketIndex < 0 ? 0 : Math.min(activePacketIndex + 1, currentPackets.length - 1);
+  setActivePacket(nextIndex);
+  if (isNarrowViewport()) {
+    setPacketFullscreen(true);
+  }
+  setStatus("Task opened. Read it, then press Check answer.");
+}
+
+function findPrimaryTaskTarget() {
+  if (activePacketIndex >= 0) {
+    return elements.packetFocus.querySelector("input, button") || elements.packetFocus;
+  }
+  return elements.openNext;
+}
+
+function maybeRenderInterrupt(summary, trayState) {
+  const top = collisionQueueItems[0];
+  const urgentFallout = smartphoneBatches[0]?.urgent === true;
+  const isUrgent = Boolean(top && top.priority <= 2) || trayState === "urgent" || urgentFallout;
+  const interruptKey = `${summary.timeHours}:${summary.currentTempo}:${trayState}:${top?.type ?? "none"}:${urgentFallout ? "fallout" : "normal"}`;
+  const shouldShow = isUrgent && dismissedInterruptKey !== interruptKey;
+
+  if (!shouldShow) {
+    elements.interrupt.classList.add("hidden");
+    return;
+  }
+
+  elements.interrupt.classList.remove("hidden");
+  if (top?.type === "crisis_interrupt") {
+    elements.interruptTitle.textContent = "Crisis interruption";
+    elements.interruptBody.textContent = top.detail;
+  } else if (top?.type === "timed_challenge") {
+    elements.interruptTitle.textContent = "Timed challenge pressure";
+    elements.interruptBody.textContent = top.detail;
+  } else if (urgentFallout) {
+    elements.interruptTitle.textContent = "Urgent fallout alert";
+    elements.interruptBody.textContent = "High-priority consequences were routed to Smartphone. Use return to continue the active packet path.";
+  } else {
+    elements.interruptTitle.textContent = `${formatTempo(summary.currentTempo)} pressure state`;
+    elements.interruptBody.textContent = "Urgent state is active. Use In-Tray or active packet to clear priority work.";
+  }
+  elements.interruptDismiss.onclick = () => {
+    dismissedInterruptKey = interruptKey;
+    elements.interrupt.classList.add("hidden");
+    setStatus("Urgent alert acknowledged.");
+  };
+  elements.interruptReturn.onclick = () => {
+    const target = findPrimaryTaskTarget();
+    target.focus();
+    setStatus("Back to your main task.");
+  };
+}
+
+function refreshPackets() {
+  if (!api) {
+    return;
+  }
+
+  const summary = api.getStateSummary();
+  const progression = api.getProgressionStatus();
+  const retrospective = api.getRetrospectiveReport({ playerAlias: "prototype-shell" });
+  currentPackets = api.getCurrentPacketBatch();
+  latestSummary = summary;
+
+  if (activePacketIndex < 0 && currentPackets.length > 0) {
+    activePacketIndex = 0;
+  } else if (activePacketIndex >= currentPackets.length) {
+    activePacketIndex = currentPackets.length > 0 ? 0 : -1;
+  }
+  if (currentPackets.length === 0) {
+    setPacketFullscreen(false);
+  }
+  if (!isNarrowViewport() && packetFullscreen) {
+    setPacketFullscreen(false);
+  }
+
+  const trayState = computeTrayState(summary, currentPackets);
+  const pressureProfile = getTempoProfile(summary.currentTempo);
+  setTempoVisualState(summary.currentTempo);
+  collisionQueueItems = buildCollisionQueue(summary, trayState);
+
+  renderSummary(summary);
+  renderProgression(progression);
+  renderRetrospective(retrospective);
+  renderTrayState(trayState, currentPackets.length);
+  renderPacketQueue();
+  renderPacketFocus();
+  elements.packetFocus.classList.remove("pressure-high", "pressure-medium");
+  if (pressureProfile.pressureClass === "crisis" || pressureProfile.pressureClass === "media_storm") {
+    elements.packetFocus.classList.add("pressure-high");
+  } else if (pressureProfile.pressureClass === "parliamentary") {
+    elements.packetFocus.classList.add("pressure-medium");
+  }
+  renderActionResult();
+  renderFalloutSurfaces();
+  renderCollisionQueue();
+  maybeRenderInterrupt(summary, trayState);
+  updateNextStep(trayState);
+
+  const topCollision = collisionQueueItems[0]?.type ?? "none";
+  const cueKey = `${summary.currentTempo}:${topCollision}`;
+  if (summary.currentTempo !== lastTempoForCue || (collisionQueueItems[0] && cueKey !== lastCollisionCueKey)) {
+    playPressureCue(summary, topCollision);
+    lastTempoForCue = summary.currentTempo;
+    lastCollisionCueKey = cueKey;
+  }
+
+  elements.focusOrderStamp.textContent = SURFACE_FOCUS_ORDER.join(" -> ");
+  setStatus("Ready. Follow the step guide above.");
+}
+
+function focusSurface(surface) {
+  surface.scrollIntoView({ behavior: reducedMotionEnabled ? "auto" : "smooth", block: "center" });
+  surface.focus({ preventScroll: true });
+}
+
+async function loadBundle() {
+  const response = await fetch("/content/vertical-slice.json");
+  if (!response.ok) {
+    throw new Error(`Failed to load content bundle (${response.status})`);
+  }
+  const bundle = await response.json();
+  validateContentBundle(bundle);
+  return bundle;
+}
+
+async function boot() {
+  setStatus("Loading vertical slice content…");
+  const bundle = await loadBundle();
+  lastAction = null;
+  dismissedInterruptKey = null;
+  falloutBatchCounter = 0;
+  smartphoneBatches = [];
+  recordLens = null;
+  bubbleShadowLead = null;
+  supplementItems = [];
+  collisionQueueItems = [];
+  lastTempoForCue = null;
+  lastCollisionCueKey = "";
+  currentPackets = [];
+  activePacketIndex = -1;
+  latestSummary = null;
+  setPacketFullscreen(false);
+  setTempoVisualState("parliamentary");
+  elements.phoneSurface.classList.remove("urgent-physical");
+  api = await PrototypeApi.create({
+    schoolYear: elements.schoolYear.value,
+    contentBundle: bundle
+  });
+  refreshPackets();
+}
+
+function wireEvents() {
+  if (elements.detailsToggle) {
+    elements.detailsToggle.addEventListener("click", () => {
+      detailsVisible = !detailsVisible;
+      applyDetailsVisibility();
+      setStatus(detailsVisible ? "Extra panels shown." : "Simple view shown.");
+    });
+  }
+
+  elements.trayAnchor.addEventListener("click", () => {
+    openNextPacketFromTray();
+  });
+  elements.openNext.addEventListener("click", () => {
+    openNextPacketFromTray();
+  });
+  elements.packetFullscreenToggle.addEventListener("click", () => {
+    setPacketFullscreen(true);
+    setStatus("Packet is now fullscreen.");
+  });
+  elements.packetFullscreenClose.addEventListener("click", () => {
+    setPacketFullscreen(false);
+    setStatus("Back to standard view.");
+  });
+  elements.audioToggle.addEventListener("click", () => {
+    audioEnabled = !audioEnabled;
+    elements.audioToggle.textContent = audioEnabled ? "Disable sound hints" : "Enable sound hints";
+    elements.audioState.textContent = audioEnabled ? "Sound hints on." : "Sound hints off.";
+    if (audioEnabled) {
+      const ctx = ensureAudioContext();
+      if (!ctx) {
+        audioEnabled = false;
+        elements.audioToggle.textContent = "Enable audio cues";
+        elements.audioState.textContent = "Sound unavailable; visual hints only.";
+      } else {
+        playPressureCue(latestSummary ?? { currentTempo: "parliamentary" }, "manual_toggle");
+      }
+    }
+  });
+  if (elements.cleanReadToggle) {
+    elements.cleanReadToggle.addEventListener("change", () => {
+      cleanReadEnabled = elements.cleanReadToggle.checked;
+      applyAccessibilityModes();
+      persistAccessibilityModes();
+      setStatus(cleanReadEnabled ? "Clean-read mode enabled." : "Clean-read mode disabled.");
+    });
+  }
+  if (elements.reducedMotionToggle) {
+    elements.reducedMotionToggle.addEventListener("change", () => {
+      reducedMotionEnabled = elements.reducedMotionToggle.checked;
+      applyAccessibilityModes();
+      persistAccessibilityModes();
+      setStatus(reducedMotionEnabled ? "Reduced-motion mode enabled." : "Reduced-motion mode disabled.");
+    });
+  }
+
+  elements.refresh.addEventListener("click", () => {
+    refreshPackets();
+  });
+
+  elements.advance.addEventListener("click", () => {
+    handleAdvanceTime();
+  });
+
+  elements.restart.addEventListener("click", async () => {
+    try {
+      await boot();
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Failed to restart prototype shell.");
+    }
+  });
+
+  elements.phoneAnchor.addEventListener("click", () => {
+    focusSurface(elements.phoneSurface);
+    setStatus("Smartphone anchor opened immediate fallout surface.");
+  });
+  elements.recordAnchor.addEventListener("click", () => {
+    focusSurface(elements.recordSurface);
+    setStatus("The Record anchor opened official summary surface.");
+  });
+  elements.bubbleAnchor.addEventListener("click", () => {
+    focusSurface(elements.bubbleSurface);
+    setStatus("The Bubble anchor opened narrative event wire.");
+  });
+  elements.supplementAnchor.addEventListener("click", () => {
+    focusSurface(elements.supplementSurface);
+    setStatus("The Supplement anchor opened optional enrichment surface.");
+  });
+  elements.lampAnchor.addEventListener("click", () => {
+    setStatus("Lamp fallback activated. Save/Quit action remains available through explicit controls.");
+  });
+
+  window.addEventListener("keydown", (event) => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+      return;
+    }
+
+    if (event.key === "Escape" && packetFullscreen) {
+      setPacketFullscreen(false);
+      setStatus("Exited fullscreen.");
+      return;
+    }
+
+    const key = event.key.toLowerCase();
+    if (key === "t") {
+      elements.trayAnchor.focus();
+      return;
+    }
+    if (key === "p") {
+      focusSurface(elements.packetFocus);
+      return;
+    }
+    if (key === "s") {
+      focusSurface(elements.phoneSurface);
+      return;
+    }
+    if (key === "r") {
+      focusSurface(elements.recordSurface);
+      return;
+    }
+    if (key === "b") {
+      focusSurface(elements.bubbleSurface);
+      return;
+    }
+    if (key === "u") {
+      focusSurface(elements.supplementSurface);
+    }
+  });
+  window.addEventListener("resize", () => {
+    if (!isNarrowViewport() && packetFullscreen) {
+      setPacketFullscreen(false);
+    }
+  });
+}
+
+loadAccessibilityModes();
+applyDetailsVisibility();
+wireEvents();
+
+boot().catch((error) => {
+  setStatus(error instanceof Error ? error.message : "Prototype shell failed to boot.");
+});

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>To The Power Prototype - Tier 1 Shell</title>
+    <link rel="stylesheet" href="/prototype/styles.css" />
+  </head>
+  <body>
+    <nav class="skip-links" aria-label="Skip links">
+      <a href="#tray-anchor">Skip to In-Tray</a>
+      <a href="#packet-focus">Skip to active packet</a>
+      <a href="#phone-surface">Skip to smartphone</a>
+      <a href="#collision-surface">Skip to collision queue</a>
+    </nav>
+    <main class="shell">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">Phase 3.6 Prototype</p>
+          <h1>Tier 1 Desk Shell</h1>
+        </div>
+        <p id="status" class="status" role="status">Booting desk shell…</p>
+      </header>
+
+      <section class="quickstart" aria-label="How to play">
+        <div>
+          <p class="interrupt-kicker">What to do now</p>
+          <p id="next-step">Open a task from In-Tray, enter a number, then press <strong>Check answer</strong>.</p>
+        </div>
+        <button id="details-toggle" type="button">Show extra panels</button>
+      </section>
+
+      <section id="interrupt" class="interrupt hidden" aria-live="assertive" aria-label="Urgent interruption">
+        <div>
+          <p class="interrupt-kicker">Urgent interruption</p>
+          <h2 id="interrupt-title">Crisis desk takeover</h2>
+          <p id="interrupt-body">Immediate action is required.</p>
+        </div>
+        <div class="interrupt-actions">
+          <button id="interrupt-return" type="button">Return to active task</button>
+          <button id="interrupt-dismiss" type="button">Acknowledge</button>
+        </div>
+      </section>
+
+      <section class="desk" aria-label="Tier 1 desk">
+        <aside class="anchor-column" aria-label="Desk anchors">
+          <button id="tray-anchor" class="desk-object tray" type="button">
+            <span class="object-title">In-Tray</span>
+            <span id="tray-state" class="object-meta">idle</span>
+          </button>
+          <button id="phone-anchor" class="desk-object" type="button">
+            <span class="object-title">Smartphone</span>
+            <span class="object-meta">fallout</span>
+          </button>
+          <button id="record-anchor" class="desk-object" type="button">
+            <span class="object-title">The Record</span>
+            <span class="object-meta">official</span>
+          </button>
+          <button id="bubble-anchor" class="desk-object" type="button">
+            <span class="object-title">The Bubble</span>
+            <span class="object-meta">rumour</span>
+          </button>
+          <button id="supplement-anchor" class="desk-object" type="button">
+            <span class="object-title">The Supplement</span>
+            <span class="object-meta">optional</span>
+          </button>
+        </aside>
+
+        <section class="packet-zone" aria-label="Active packet zone">
+          <header class="zone-header">
+            <div>
+              <h2>Active Packet</h2>
+              <p id="packet-count" class="meta">0 packets</p>
+            </div>
+            <div class="zone-actions">
+              <button id="packet-fullscreen-toggle" type="button">Fullscreen packet</button>
+              <button id="packet-fullscreen-close" class="hidden" type="button">Close fullscreen</button>
+              <button id="open-next" type="button">Open next task</button>
+            </div>
+          </header>
+          <div id="packet-focus" class="packet-focus" tabindex="-1" aria-live="polite"></div>
+          <div id="packets" class="packet-queue" aria-label="Packet queue"></div>
+        </section>
+
+        <aside class="surface-column" aria-label="Support surfaces">
+          <section id="diary-surface" class="surface-card" aria-label="Diary and controls" tabindex="-1">
+            <header class="surface-header">
+              <h2>Diary</h2>
+              <span id="focus-order-stamp" class="meta">focus order set</span>
+            </header>
+            <div class="controls">
+              <label>
+                School year
+                <select id="school-year">
+                  <option value="Y9">Year 9</option>
+                  <option value="Y10">Year 10</option>
+                  <option value="Y11">Year 11</option>
+                </select>
+              </label>
+              <label>
+                Advance hours
+                <input id="advance-hours" type="number" min="1" step="1" value="6" />
+              </label>
+              <div class="button-row">
+                <button id="advance" type="button">Advance time</button>
+                <button id="refresh" type="button">Refresh batch</button>
+                <button id="restart" type="button">Restart shell</button>
+              </div>
+              <fieldset class="accessibility-controls">
+                <legend>Accessibility modes</legend>
+                <label class="toggle-row">
+                  <input id="clean-read-toggle" type="checkbox" />
+                  Clean-read and contrast simplification
+                </label>
+                <label class="toggle-row">
+                  <input id="reduced-motion-toggle" type="checkbox" />
+                  Reduced motion override
+                </label>
+              </fieldset>
+              <p class="meta keyboard-hint">Shortcuts: `t` tray, `p` packet, `s` phone, `r` record, `b` bubble, `u` supplement.</p>
+            </div>
+          </section>
+
+          <section id="clock-surface" class="surface-card" aria-label="Clock" tabindex="-1">
+            <header class="surface-header">
+              <h2>Clock</h2>
+              <span id="tempo-state" class="meta">tempo</span>
+            </header>
+            <p id="clock-readout" class="clock-readout">tempo unknown</p>
+            <p id="audio-state" class="meta">audio cues off</p>
+            <button id="audio-toggle" type="button">Enable audio cues</button>
+          </section>
+
+          <section class="surface-card lamp-card" aria-label="Lamp and save path">
+            <header class="surface-header">
+              <h2>Lamp</h2>
+            </header>
+            <button id="lamp-anchor" type="button">Save/Quit fallback (status only)</button>
+          </section>
+        </aside>
+      </section>
+
+      <section class="detail-grid" aria-label="Consequences and diagnostics">
+        <article id="record-surface" class="panel" tabindex="-1">
+          <div class="panel-header">
+            <h2>State summary</h2>
+            <span id="summary-stamp" class="meta"></span>
+          </div>
+          <div id="record-stat" class="record-stat">
+            <p class="meta">Record lens</p>
+            <p>No major state movement recorded yet.</p>
+          </div>
+          <dl id="summary" class="summary"></dl>
+        </article>
+
+        <article class="panel">
+          <div class="panel-header">
+            <h2>Progression</h2>
+            <span id="promotion-stamp" class="meta"></span>
+          </div>
+          <div id="progression" class="progression"></div>
+        </article>
+
+        <article id="retrospective-surface" class="panel">
+          <div class="panel-header">
+            <h2>Retrospective</h2>
+            <span id="retrospective-stamp" class="meta"></span>
+          </div>
+          <div id="retrospective-summary" class="retrospective-summary">
+            <p>Retrospective snapshot will appear after your first actions.</p>
+          </div>
+          <div id="leaderboard-summary" class="leaderboard-summary">
+            <p>Legacy score and leaderboard entry are not available yet.</p>
+          </div>
+        </article>
+
+        <article id="phone-surface" class="panel" tabindex="-1">
+          <div class="panel-header">
+            <h2>Smartphone feed</h2>
+            <span id="action-type" class="meta">none yet</span>
+          </div>
+          <div id="phone-batches" class="phone-batches">
+            <p>No fallout updates queued yet.</p>
+          </div>
+          <div id="action-result" class="action-result">
+            <p>No challenge outcome or time advance has been submitted yet.</p>
+          </div>
+        </article>
+
+        <article id="bubble-surface" class="panel panel-wide" tabindex="-1">
+          <div class="panel-header">
+            <h2>Bubble wire</h2>
+            <span id="event-count" class="meta">0 emitted</span>
+          </div>
+          <div id="bubble-lead" class="bubble-lead">
+            <h3>Shadow lead</h3>
+            <p>No narrative lead is active yet.</p>
+          </div>
+          <div id="event-log" class="event-log">
+            <p>No events emitted yet.</p>
+          </div>
+        </article>
+
+        <article id="collision-surface" class="panel panel-wide" tabindex="-1">
+          <div class="panel-header">
+            <h2>Collision Queue</h2>
+            <span id="collision-stamp" class="meta">priority order</span>
+          </div>
+          <div id="collision-queue" class="collision-queue">
+            <p>No queue pressure.</p>
+          </div>
+        </article>
+
+        <article id="supplement-surface" class="panel panel-wide" tabindex="-1">
+          <div class="panel-header">
+            <h2>The Supplement</h2>
+            <span id="supplement-stamp" class="meta">optional</span>
+          </div>
+          <div id="supplement-list" class="supplement-list">
+            <p>No supplementary items queued.</p>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script type="module" src="/prototype/app.js"></script>
+  </body>
+</html>

--- a/prototype/runtime-api.js
+++ b/prototype/runtime-api.js
@@ -1,0 +1,194 @@
+import { executeCommandWithResult } from "/dist/domain/commands.js";
+import { selectCurrentContentBatch } from "/dist/content/selection.js";
+import { buildRetrospectiveReport } from "/dist/application/retrospective.js";
+import { createInitialGameState } from "/dist/domain/state.js";
+
+const ROLE_ORDER = ["backbencher", "pps", "junior_minister", "minister_of_state", "cabinet", "pm"];
+
+function mapPacket(selection) {
+  const packet = { band: selection.band };
+
+  if (selection.eventCard) {
+    packet.eventCard = {
+      id: selection.eventCard.id,
+      title: selection.eventCard.title,
+      description: selection.eventCard.description
+    };
+  }
+
+  if (selection.challenge) {
+    packet.challenge = {
+      id: selection.challenge.id,
+      topic: selection.challenge.topic,
+      mode: selection.challenge.mode,
+      prompt: selection.challenge.prompt,
+      unit: selection.challenge.unit,
+      timed: selection.challenge.timed ?? false,
+      timerSeconds: selection.challenge.timerSeconds,
+      expectedAnswer: selection.challenge.answer,
+      tolerance: selection.challenge.tolerance
+    };
+  }
+
+  if (selection.scene) {
+    packet.scene = {
+      id: selection.scene.id,
+      npcId: selection.scene.npcId,
+      text: selection.scene.text
+    };
+  }
+
+  return packet;
+}
+
+function getStateSummary(state) {
+  return {
+    schoolYear: state.schoolYear,
+    currentRole: state.currentRole,
+    currentTempo: state.currentTempo,
+    timeHours: state.timeHours,
+    partyLoyaltyScore: state.partyLoyaltyScore,
+    publicApproval: state.publicApproval,
+    constituencyApproval: state.constituencyApproval,
+    pressRelationship: state.pressRelationship,
+    darkIndex: state.darkIndex,
+    pendingRemediations: state.pendingRemediations.length,
+    activeTimedChallenges: Object.keys(state.activeTimedChallenges).length,
+    eventLogEntries: state.eventLog.length
+  };
+}
+
+function evaluateRequirements(summary, nextRole) {
+  if (!nextRole) {
+    return [];
+  }
+
+  const gates = {
+    pps: [
+      { key: "partyLoyaltyScore", label: "Party loyalty", target: 45 },
+      { key: "publicApproval", label: "Public approval", target: 42 }
+    ],
+    junior_minister: [
+      { key: "partyLoyaltyScore", label: "Party loyalty", target: 50 },
+      { key: "publicApproval", label: "Public approval", target: 45 },
+      { key: "pressRelationship", label: "Press relationship", target: 40 }
+    ],
+    minister_of_state: [
+      { key: "partyLoyaltyScore", label: "Party loyalty", target: 56 },
+      { key: "publicApproval", label: "Public approval", target: 48 }
+    ],
+    cabinet: [
+      { key: "partyLoyaltyScore", label: "Party loyalty", target: 62 },
+      { key: "publicApproval", label: "Public approval", target: 52 },
+      { key: "pressRelationship", label: "Press relationship", target: 46 }
+    ],
+    pm: [
+      { key: "partyLoyaltyScore", label: "Party loyalty", target: 70 },
+      { key: "publicApproval", label: "Public approval", target: 58 },
+      { key: "constituencyApproval", label: "Constituency approval", target: 52 }
+    ]
+  };
+
+  return (gates[nextRole] ?? []).map((gate) => {
+    const current = summary[gate.key];
+    return {
+      label: gate.label,
+      current,
+      target: gate.target,
+      met: current >= gate.target
+    };
+  });
+}
+
+function getProgressionStatus(state) {
+  const summary = getStateSummary(state);
+  const roleIndex = ROLE_ORDER.indexOf(summary.currentRole);
+  const nextRole = ROLE_ORDER[roleIndex + 1] ?? null;
+  const requirements = evaluateRequirements(summary, nextRole);
+  const ready = requirements.length > 0 ? requirements.every((entry) => entry.met) : false;
+
+  const career = summary.darkIndex >= 80
+    ? {
+      kind: "risk",
+      title: "Career risk elevated",
+      detail: "Dark-index pressure is high. Stabilize fallout before pushing promotion gates."
+    }
+    : {
+      kind: "ongoing",
+      title: "Career path active",
+      detail: nextRole
+        ? `Maintaining current trajectory toward ${nextRole.replaceAll("_", " ")}.`
+        : "Top role reached for current progression model."
+    };
+
+  return {
+    promotion: {
+      currentRole: summary.currentRole,
+      nextRole,
+      ready,
+      requirements
+    },
+    career
+  };
+}
+
+function mapCommandResult(state, result) {
+  return {
+    summary: getStateSummary(state),
+    warnings: result.warnings,
+    events: result.events
+  };
+}
+
+export class PrototypeApi {
+  constructor(state, bundle, rng = Math.random) {
+    this.state = state;
+    this.bundle = bundle;
+    this.rng = rng;
+  }
+
+  static async create(options = {}) {
+    if (!options.contentBundle) {
+      throw new Error("PrototypeApi.create requires contentBundle in browser shell.");
+    }
+    const schoolYear = options.schoolYear ?? "Y10";
+    return new PrototypeApi(createInitialGameState(schoolYear), options.contentBundle, options.rng);
+  }
+
+  getCurrentPacketBatch(burstCount) {
+    return selectCurrentContentBatch(this.state, this.bundle, burstCount).map(mapPacket);
+  }
+
+  submitChallengeOutcome(input) {
+    const command = {
+      type: "submit_challenge_answer",
+      topic: input.topic,
+      correct: input.correct
+    };
+    if (input.mode !== undefined) {
+      command.mode = input.mode;
+    }
+    const result = executeCommandWithResult(this.state, command, this.rng);
+    this.state = result.state;
+    return mapCommandResult(this.state, result);
+  }
+
+  advanceTime(hours) {
+    const command = hours === undefined ? { type: "advance_time" } : { type: "advance_time", hours };
+    const result = executeCommandWithResult(this.state, command, this.rng);
+    this.state = result.state;
+    return mapCommandResult(this.state, result);
+  }
+
+  getStateSummary() {
+    return getStateSummary(this.state);
+  }
+
+  getProgressionStatus() {
+    return getProgressionStatus(this.state);
+  }
+
+  getRetrospectiveReport(input = {}) {
+    return buildRetrospectiveReport(this.state, input);
+  }
+}

--- a/prototype/styles.css
+++ b/prototype/styles.css
@@ -1,0 +1,863 @@
+:root {
+  color-scheme: light;
+  --ink: #191c22;
+  --muted: #4f5767;
+  --paper: #f7f1e5;
+  --card: #fbf7ef;
+  --desk: #c9a57b;
+  --desk-deep: #9f7f5c;
+  --wood-grain-a: rgba(106, 70, 40, 0.16);
+  --wood-grain-b: rgba(255, 239, 214, 0.1);
+  --accent: #7b2e21;
+  --accent-soft: #edd1bc;
+  --line: rgba(28, 31, 39, 0.18);
+  --urgent: #a32626;
+  --ok: #2f6242;
+  --shadow: 0 22px 44px rgba(32, 24, 18, 0.2);
+  --surface-shine: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  --focus-ring: 0 0 0 3px rgba(123, 46, 33, 0.3);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(143, 60, 45, 0.16), transparent 34%),
+    linear-gradient(180deg, #e8d8bf 0%, #ddc9aa 52%, #d3bc98 100%);
+  color: var(--ink);
+  font-family: "Baskerville", Georgia, "Times New Roman", serif;
+}
+
+body.clean-read {
+  --paper: #fcfbf8;
+  --card: #ffffff;
+  --line: rgba(16, 20, 28, 0.28);
+  --muted: #2f3848;
+  --accent: #5f160c;
+  --shadow: 0 8px 20px rgba(22, 20, 17, 0.12);
+  background: #f5f5f2;
+}
+
+body.clean-read .desk {
+  background: linear-gradient(180deg, #ece6dc 0%, #dfd6c8 100%);
+}
+
+body.clean-read .packet-zone,
+body.clean-read .panel,
+body.clean-read .surface-card,
+body.clean-read .desk-object {
+  background: #ffffff;
+}
+
+body.clean-read .panel.urgent-physical,
+body.clean-read .phone-batch.urgent,
+body.clean-read .collision-item.priority-1,
+body.clean-read .packet-focus.pressure-high {
+  border-color: #8f1010;
+  background: #fff6f6;
+}
+
+body.reduced-motion *,
+body.reduced-motion *::before,
+body.reduced-motion *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+.skip-links {
+  position: absolute;
+  left: 0.75rem;
+  top: 0.5rem;
+  display: flex;
+  gap: 0.45rem;
+  z-index: 60;
+}
+
+.skip-links a {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  background: #fff;
+  color: var(--ink);
+  padding: 0.4rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  font-size: 0.82rem;
+  text-decoration: none;
+}
+
+.skip-links a:focus {
+  position: static;
+  left: auto;
+}
+
+body.tempo-recess {
+  background:
+    radial-gradient(circle at 15% 0%, rgba(79, 129, 96, 0.14), transparent 34%),
+    linear-gradient(180deg, #e9e2d1 0%, #e2d8c4 52%, #dacdb7 100%);
+}
+
+body.tempo-parliamentary {
+  background:
+    radial-gradient(circle at 10% 0%, rgba(143, 60, 45, 0.18), transparent 32%),
+    linear-gradient(180deg, #efe3d1 0%, #e7dbc8 50%, #dfd1bc 100%);
+}
+
+body.tempo-crisis {
+  background:
+    radial-gradient(circle at 10% 0%, rgba(163, 38, 38, 0.26), transparent 34%),
+    linear-gradient(180deg, #ead7d0 0%, #e4cfc6 50%, #dac2b9 100%);
+}
+
+body.tempo-media_storm {
+  background:
+    radial-gradient(circle at 85% 10%, rgba(118, 76, 24, 0.24), transparent 36%),
+    radial-gradient(circle at 15% 0%, rgba(163, 38, 38, 0.2), transparent 32%),
+    linear-gradient(180deg, #e8d8cf 0%, #dccbbf 52%, #d2c0b3 100%);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.shell {
+  width: min(1240px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.25rem 0 2rem;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.quickstart {
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--line) 65%);
+  background: #fff8ef;
+  border-radius: 12px;
+  padding: 0.7rem 0.9rem;
+  margin-bottom: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.quickstart button {
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, #fff 0%, #f1e8d7 100%);
+  border-radius: 999px;
+  padding: 0.5rem 0.8rem;
+}
+
+#open-next {
+  font-weight: 700;
+}
+
+.eyebrow,
+.status,
+.meta,
+.object-meta {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.eyebrow {
+  margin: 0 0 0.4rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2.2rem, 4.8vw, 3.2rem);
+  line-height: 1;
+}
+
+.status {
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-align: right;
+  max-width: 26rem;
+}
+
+.interrupt {
+  border: 1px solid rgba(163, 38, 38, 0.45);
+  background: #fff3f1;
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  box-shadow: 0 10px 18px rgba(163, 38, 38, 0.16);
+  margin-bottom: 1rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.interrupt-kicker {
+  color: var(--urgent);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.interrupt h2 {
+  font-size: 1.2rem;
+  margin-top: 0.2rem;
+}
+
+.interrupt p + p {
+  margin-top: 0.3rem;
+}
+
+.interrupt-actions {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.desk {
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background:
+    repeating-linear-gradient(
+      12deg,
+      var(--wood-grain-a) 0px,
+      var(--wood-grain-a) 2px,
+      transparent 2px,
+      transparent 7px
+    ),
+    linear-gradient(150deg, var(--wood-grain-b), transparent 36%),
+    linear-gradient(180deg, var(--desk) 0%, var(--desk-deep) 100%);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) 320px;
+  gap: 0.9rem;
+}
+
+.anchor-column,
+.surface-column {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.desk-object,
+.surface-card,
+.packet-zone,
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.66), rgba(255, 255, 255, 0.15)),
+    color-mix(in srgb, var(--card) 96%, white 4%);
+  box-shadow: var(--surface-shine);
+}
+
+.desk-object {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.7rem 0.8rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.desk-object.tray {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line) 60%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-soft) 65%, white 35%);
+}
+
+.object-title {
+  font-size: 1.02rem;
+}
+
+.object-meta,
+.meta {
+  font-size: 0.66rem;
+  color: var(--muted);
+}
+
+.packet-zone,
+.surface-card,
+.panel {
+  padding: 0.85rem;
+}
+
+.packet-zone {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.zone-header,
+.surface-header,
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  align-items: baseline;
+}
+
+.zone-actions {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: end;
+}
+
+.zone-header button,
+.button-row button,
+.interrupt-actions button,
+.lamp-card button {
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, #fff 0%, #f1e8d7 100%);
+  border-radius: 999px;
+  padding: 0.56rem 0.82rem;
+}
+
+button:hover,
+button:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--line) 52%);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+a:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.packet-focus {
+  min-height: 300px;
+  border: 1px dashed color-mix(in srgb, var(--line) 72%, var(--muted) 28%);
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 70% 0%, rgba(255, 255, 255, 0.8), transparent 30%),
+    var(--paper);
+  padding: 0.8rem;
+}
+
+.packet {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.packet.packet-crisis {
+  border: 1px solid rgba(163, 38, 38, 0.45);
+  border-radius: 10px;
+  padding: 0.55rem;
+  background: #fff4f2;
+}
+
+.doc-kicker {
+  font-family: "Trebuchet MS", sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.packet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 0.7rem;
+}
+
+.badge {
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.18rem 0.5rem;
+  font-size: 0.72rem;
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.packet-section {
+  border-top: 1px solid var(--line);
+  padding-top: 0.65rem;
+}
+
+.packet-section p {
+  margin-top: 0.28rem;
+  color: var(--muted);
+}
+
+.packet-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.packet-actions button {
+  border: 1px solid var(--line);
+  background: white;
+  border-radius: 999px;
+  padding: 0.45rem 0.72rem;
+}
+
+.challenge-form {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.45rem;
+}
+
+.challenge-form label {
+  display: grid;
+  gap: 0.25rem;
+  color: var(--muted);
+  font-family: "Trebuchet MS", sans-serif;
+  font-size: 0.83rem;
+}
+
+.challenge-form input {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.4rem 0.55rem;
+  background: #fff;
+}
+
+.challenge-help {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.scene-attachment {
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0.55rem 0.65rem;
+}
+
+.scene-attachment h4 {
+  margin: 0 0 0.2rem;
+  font-size: 0.95rem;
+}
+
+.packet-queue {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 0.45rem;
+}
+
+.queue-item {
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 10px;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+}
+
+.queue-item.active {
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--line) 52%);
+  background: #fff8f4;
+}
+
+.controls {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.accessibility-controls {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.5rem 0.6rem;
+  margin: 0;
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.accessibility-controls legend {
+  padding: 0 0.3rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+}
+
+.keyboard-hint {
+  margin-top: 0.15rem;
+}
+
+.controls label {
+  display: grid;
+  gap: 0.25rem;
+  color: var(--muted);
+  font-family: "Trebuchet MS", sans-serif;
+  font-size: 0.86rem;
+}
+
+.controls input,
+.controls select {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  padding: 0.45rem 0.58rem;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.clock-readout {
+  color: var(--muted);
+}
+
+.collision-queue {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.collision-item {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  padding: 0.55rem 0.65rem;
+}
+
+.collision-item h3 {
+  font-size: 0.94rem;
+}
+
+.collision-item p {
+  margin-top: 0.2rem;
+  color: var(--muted);
+}
+
+.collision-item.priority-1 {
+  border-color: rgba(163, 38, 38, 0.65);
+  background: #fff3f1;
+}
+
+.collision-item.priority-2 {
+  border-color: rgba(163, 38, 38, 0.42);
+}
+
+.packet-focus.pressure-high {
+  border-color: rgba(163, 38, 38, 0.62);
+  box-shadow: inset 0 0 0 1px rgba(163, 38, 38, 0.18);
+}
+
+.packet-focus.pressure-medium {
+  border-color: rgba(143, 60, 45, 0.45);
+}
+
+#audio-toggle {
+  margin-top: 0.45rem;
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.48rem 0.72rem;
+}
+
+body.tempo-crisis .desk,
+body.tempo-media_storm .desk {
+  box-shadow: 0 22px 44px rgba(84, 44, 32, 0.2);
+}
+
+body.tempo-media_storm .phone-batch {
+  background: #fff8ef;
+}
+
+body.tempo-crisis .phone-batch.urgent,
+body.tempo-media_storm .phone-batch.urgent {
+  border-width: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  body.tempo-media_storm .panel.urgent-physical {
+    animation: tempo-alert-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes tempo-alert-pulse {
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-1px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+.detail-grid {
+  margin-top: 0.95rem;
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.panel-wide {
+  grid-column: span 3;
+}
+
+body:not(.details-expanded) .surface-column,
+body:not(.details-expanded) .detail-grid,
+body:not(.details-expanded) #phone-anchor,
+body:not(.details-expanded) #record-anchor,
+body:not(.details-expanded) #bubble-anchor,
+body:not(.details-expanded) #supplement-anchor {
+  display: none;
+}
+
+body:not(.details-expanded) .desk {
+  grid-template-columns: 240px minmax(0, 1fr);
+}
+
+body:not(.details-expanded) #bubble-surface,
+body:not(.details-expanded) #collision-surface,
+body:not(.details-expanded) #supplement-surface {
+  display: none;
+}
+
+.summary {
+  margin: 0;
+  display: grid;
+  gap: 0.45rem 0.8rem;
+  grid-template-columns: 1fr auto;
+}
+
+.summary dt {
+  color: var(--muted);
+}
+
+.summary dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.progression,
+.action-result,
+.event-log,
+.retrospective-summary,
+.leaderboard-summary {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.record-stat {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: linear-gradient(180deg, #fff 0%, #f8f1e5 100%);
+  padding: 0.55rem 0.65rem;
+  margin-bottom: 0.65rem;
+}
+
+.record-value {
+  font-weight: 600;
+}
+
+.phone-batches {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.55rem;
+}
+
+.phone-batch {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: linear-gradient(180deg, #ffffff 0%, #f5ede1 100%);
+  padding: 0.5rem 0.6rem;
+}
+
+.phone-batch h3 {
+  font-size: 0.9rem;
+  margin-bottom: 0.28rem;
+}
+
+.phone-batch ul {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--muted);
+}
+
+.phone-batch.urgent {
+  border-color: rgba(163, 38, 38, 0.55);
+  background: #fff3f1;
+}
+
+.phone-batch.severity-elevated {
+  border-color: rgba(143, 60, 45, 0.4);
+}
+
+.phone-batch.severity-high {
+  border-color: rgba(163, 38, 38, 0.52);
+}
+
+.phone-batch.severity-critical {
+  border-width: 2px;
+}
+
+.panel.urgent-physical {
+  box-shadow:
+    0 0 0 2px rgba(163, 38, 38, 0.22),
+    0 16px 26px rgba(163, 38, 38, 0.14);
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(163, 38, 38, 0.06),
+      rgba(163, 38, 38, 0.06) 8px,
+      rgba(255, 255, 255, 0.92) 8px,
+      rgba(255, 255, 255, 0.92) 16px
+    );
+}
+
+.bubble-lead {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: linear-gradient(180deg, #fff 0%, #f8f0e5 100%);
+  padding: 0.6rem 0.7rem;
+  margin-bottom: 0.6rem;
+}
+
+.bubble-lead h3 {
+  font-size: 1rem;
+}
+
+.bubble-lead p {
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+.supplement-list ul {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.supplement-list li {
+  color: var(--muted);
+}
+
+.progression-card,
+.action-card,
+.event-item,
+.retrospective-card {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.6rem 0.7rem;
+}
+
+.progression-card p,
+.progression-card li,
+.action-card p,
+.event-item p,
+.retrospective-card p {
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 1100px) {
+  .desk {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .surface-column {
+    grid-column: span 2;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .shell {
+    width: min(100% - 1rem, 1240px);
+    padding-top: 0.9rem;
+  }
+
+  .topbar {
+    display: grid;
+    align-items: start;
+  }
+
+  .status {
+    text-align: left;
+  }
+
+  .interrupt {
+    display: grid;
+  }
+
+  .desk {
+    grid-template-columns: 1fr;
+  }
+
+  .surface-column {
+    grid-column: auto;
+    grid-template-columns: 1fr;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-wide {
+    grid-column: auto;
+  }
+
+  body.packet-fullscreen .desk {
+    display: block;
+    border-radius: 0;
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+    background: transparent;
+  }
+
+  body.packet-fullscreen .anchor-column,
+  body.packet-fullscreen .surface-column,
+  body.packet-fullscreen .detail-grid,
+  body.packet-fullscreen .topbar,
+  body.packet-fullscreen #interrupt {
+    display: none;
+  }
+
+  body.packet-fullscreen .packet-zone {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    border-radius: 0;
+    border: 0;
+    background: var(--paper);
+    padding: 1rem;
+    overflow-y: auto;
+    align-content: start;
+  }
+
+  body.packet-fullscreen .packet-focus {
+    min-height: min(72vh, 560px);
+  }
+}

--- a/src/application/prototype-api.ts
+++ b/src/application/prototype-api.ts
@@ -1,6 +1,8 @@
 import { resolve } from "node:path";
 import type { CurrentSelection } from "../content/selection.js";
 import { GameService } from "./game-service.js";
+import { buildRetrospectiveReport } from "./retrospective.js";
+import type { RetrospectiveReport } from "./retrospective.js";
 import type { CommandResult, CommandWarning, GameCommand } from "../domain/commands.js";
 import type { ChallengeMode, GameEvent, GameState, MathsTopic, Rng, SchoolYear } from "../domain/types.js";
 
@@ -58,6 +60,11 @@ export interface PrototypeCommandResponse {
   summary: PrototypeStateSummary;
   warnings: CommandWarning[];
   events: GameEvent[];
+}
+
+export interface PrototypeRetrospectiveInput {
+  runId?: string;
+  playerAlias?: string;
 }
 
 function mapPacket(selection: CurrentSelection): PrototypePacket {
@@ -183,5 +190,9 @@ export class PrototypeApi {
 
   getStateSummary(): PrototypeStateSummary {
     return getStateSummary(this.service.getState());
+  }
+
+  getRetrospectiveReport(input: PrototypeRetrospectiveInput = {}): RetrospectiveReport {
+    return buildRetrospectiveReport(this.service.getState(), input);
   }
 }

--- a/src/application/retrospective.ts
+++ b/src/application/retrospective.ts
@@ -1,0 +1,288 @@
+import { reduceEvents } from "../domain/reducer.js";
+import { createInitialGameState } from "../domain/state.js";
+import type { CareerLevel, GameEvent, GameEventType, GameState, Rng } from "../domain/types.js";
+
+const ROLE_ORDER: CareerLevel[] = ["backbencher", "pps", "junior_minister", "minister_of_state", "cabinet", "pm"];
+const EVENT_TYPES: GameEventType[] = [
+  "SchoolYearSet",
+  "RoleChanged",
+  "TempoChanged",
+  "TimeAdvanced",
+  "ChallengeAttempted",
+  "RemediationTriggered",
+  "TimedChallengeStarted",
+  "TimedChallengeExpired",
+  "LatentConsequenceRegistered",
+  "LatentConsequenceTriggered",
+  "NPCRelationshipChanged",
+  "DarkIndexChanged"
+];
+
+export interface RetrospectiveSummary {
+  schoolYear: GameState["schoolYear"];
+  finalRole: CareerLevel;
+  peakRole: CareerLevel;
+  finalTempo: GameState["currentTempo"];
+  totalHours: number;
+  finalScores: {
+    partyLoyalty: number;
+    publicApproval: number;
+    constituencyApproval: number;
+    pressRelationship: number;
+    darkIndex: number;
+  };
+  challengeStats: {
+    attempts: number;
+    correct: number;
+    incorrect: number;
+    accuracy: number;
+    topicsAttempted: number;
+  };
+  remediationTriggered: number;
+  activeTimedChallenges: number;
+  pendingRemediations: number;
+}
+
+export interface LegacySummary {
+  score: number;
+  band: "fragile" | "developing" | "established" | "dominant";
+  rationale: string;
+}
+
+export interface LeaderboardEntry {
+  modelVersion: "legacy-v1";
+  runId: string;
+  playerAlias: string;
+  legacyScore: number;
+  peakRole: CareerLevel;
+  finalRole: CareerLevel;
+  totalHours: number;
+  challengeAccuracy: number;
+  remediationTriggered: number;
+  timestampIso: string;
+}
+
+export interface ReplayConsistency {
+  deterministic: boolean;
+  checkedFields: string[];
+  mismatches: string[];
+}
+
+export interface RetrospectiveReport {
+  schemaVersion: "retrospective-v1";
+  summary: RetrospectiveSummary;
+  eventCounts: Record<GameEventType, number>;
+  legacy: LegacySummary;
+  leaderboardEntry: LeaderboardEntry;
+  replay: ReplayConsistency;
+}
+
+export interface BuildRetrospectiveOptions {
+  runId?: string;
+  playerAlias?: string;
+  seedState?: GameState;
+  rng?: Rng;
+  now?: Date;
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+function countEvents(events: GameEvent[]): Record<GameEventType, number> {
+  const counts = Object.fromEntries(EVENT_TYPES.map((type) => [type, 0])) as Record<GameEventType, number>;
+  for (const event of events) {
+    counts[event.type] += 1;
+  }
+  return counts;
+}
+
+function findPeakRole(state: GameState): CareerLevel {
+  const roleSeen = new Set<CareerLevel>([state.currentRole]);
+  for (const event of state.eventLog) {
+    if (event.type !== "RoleChanged") {
+      continue;
+    }
+    const role = event.payload.role;
+    if (
+      role === "backbencher" ||
+      role === "pps" ||
+      role === "junior_minister" ||
+      role === "minister_of_state" ||
+      role === "cabinet" ||
+      role === "pm"
+    ) {
+      roleSeen.add(role);
+    }
+  }
+
+  let peak: CareerLevel = "backbencher";
+  for (const role of ROLE_ORDER) {
+    if (roleSeen.has(role)) {
+      peak = role;
+    }
+  }
+  return peak;
+}
+
+function computeChallengeStats(events: GameEvent[]): RetrospectiveSummary["challengeStats"] {
+  let attempts = 0;
+  let correct = 0;
+  const topics = new Set<string>();
+
+  for (const event of events) {
+    if (event.type !== "ChallengeAttempted") {
+      continue;
+    }
+    attempts += 1;
+    if (event.payload.correct === true) {
+      correct += 1;
+    }
+    const topic = event.payload.topic;
+    if (typeof topic === "string" && topic.length > 0) {
+      topics.add(topic);
+    }
+  }
+
+  const incorrect = attempts - correct;
+  const accuracy = attempts === 0 ? 0 : Math.round((correct / attempts) * 100);
+  return {
+    attempts,
+    correct,
+    incorrect,
+    accuracy,
+    topicsAttempted: topics.size
+  };
+}
+
+function computeLegacySummary(state: GameState, challengeAccuracy: number): LegacySummary {
+  const composite = Math.round(
+    state.partyLoyaltyScore * 0.24 +
+    state.publicApproval * 0.24 +
+    state.constituencyApproval * 0.18 +
+    state.pressRelationship * 0.16 +
+    challengeAccuracy * 0.18 -
+    state.darkIndex * 0.2
+  );
+  const score = clampPercent(composite);
+
+  if (score >= 75) {
+    return {
+      score,
+      band: "dominant",
+      rationale: "Broad approval remained strong while risk pressure stayed contained."
+    };
+  }
+  if (score >= 60) {
+    return {
+      score,
+      band: "established",
+      rationale: "A stable record with more strengths than liabilities."
+    };
+  }
+  if (score >= 40) {
+    return {
+      score,
+      band: "developing",
+      rationale: "Mixed outcomes kept progression viable but not secure."
+    };
+  }
+  return {
+    score,
+    band: "fragile",
+    rationale: "Risk, misses, or weak support outweighed headline progress."
+  };
+}
+
+function buildReplayConsistency(state: GameState, seedState: GameState, rng: Rng): ReplayConsistency {
+  const replayed = reduceEvents(seedState, state.eventLog, rng, { evaluateLatent: false });
+  const checkedFields = [
+    "schoolYear",
+    "currentRole",
+    "currentTempo",
+    "timeHours",
+    "partyLoyaltyScore",
+    "publicApproval",
+    "constituencyApproval",
+    "pressRelationship",
+    "darkIndex",
+    "pendingRemediations.length",
+    "activeTimedChallenges.count",
+    "eventLog.length"
+  ];
+  const mismatches: string[] = [];
+
+  const compare = (label: string, left: number | string, right: number | string) => {
+    if (left !== right) {
+      mismatches.push(`${label}: expected ${String(left)} got ${String(right)}`);
+    }
+  };
+
+  compare("schoolYear", state.schoolYear, replayed.schoolYear);
+  compare("currentRole", state.currentRole, replayed.currentRole);
+  compare("currentTempo", state.currentTempo, replayed.currentTempo);
+  compare("timeHours", state.timeHours, replayed.timeHours);
+  compare("partyLoyaltyScore", state.partyLoyaltyScore, replayed.partyLoyaltyScore);
+  compare("publicApproval", state.publicApproval, replayed.publicApproval);
+  compare("constituencyApproval", state.constituencyApproval, replayed.constituencyApproval);
+  compare("pressRelationship", state.pressRelationship, replayed.pressRelationship);
+  compare("darkIndex", state.darkIndex, replayed.darkIndex);
+  compare("pendingRemediations.length", state.pendingRemediations.length, replayed.pendingRemediations.length);
+  compare("activeTimedChallenges.count", Object.keys(state.activeTimedChallenges).length, Object.keys(replayed.activeTimedChallenges).length);
+  compare("eventLog.length", state.eventLog.length, replayed.eventLog.length);
+
+  return {
+    deterministic: mismatches.length === 0,
+    checkedFields,
+    mismatches
+  };
+}
+
+export function buildRetrospectiveReport(state: GameState, options: BuildRetrospectiveOptions = {}): RetrospectiveReport {
+  const challengeStats = computeChallengeStats(state.eventLog);
+  const legacy = computeLegacySummary(state, challengeStats.accuracy);
+  const replay = buildReplayConsistency(
+    state,
+    options.seedState ?? createInitialGameState(state.schoolYear),
+    options.rng ?? Math.random
+  );
+  const now = options.now ?? new Date();
+  const peakRole = findPeakRole(state);
+
+  return {
+    schemaVersion: "retrospective-v1",
+    summary: {
+      schoolYear: state.schoolYear,
+      finalRole: state.currentRole,
+      peakRole,
+      finalTempo: state.currentTempo,
+      totalHours: state.timeHours,
+      finalScores: {
+        partyLoyalty: state.partyLoyaltyScore,
+        publicApproval: state.publicApproval,
+        constituencyApproval: state.constituencyApproval,
+        pressRelationship: state.pressRelationship,
+        darkIndex: state.darkIndex
+      },
+      challengeStats,
+      remediationTriggered: state.eventLog.filter((event) => event.type === "RemediationTriggered").length,
+      activeTimedChallenges: Object.keys(state.activeTimedChallenges).length,
+      pendingRemediations: state.pendingRemediations.length
+    },
+    eventCounts: countEvents(state.eventLog),
+    legacy,
+    leaderboardEntry: {
+      modelVersion: "legacy-v1",
+      runId: options.runId ?? `run-${state.schoolYear}-${state.timeHours}h-${state.eventLog.length}e`,
+      playerAlias: options.playerAlias ?? "desk-shell",
+      legacyScore: legacy.score,
+      peakRole,
+      finalRole: state.currentRole,
+      totalHours: state.timeHours,
+      challengeAccuracy: challengeStats.accuracy,
+      remediationTriggered: state.eventLog.filter((event) => event.type === "RemediationTriggered").length,
+      timestampIso: now.toISOString()
+    },
+    replay
+  };
+}

--- a/src/tests/prototype-api.test.ts
+++ b/src/tests/prototype-api.test.ts
@@ -63,3 +63,24 @@ test("PrototypeApi.create loads content and exposes packet batch", async () => {
   const packets = api.getCurrentPacketBatch();
   assert.equal(packets.length >= 1, true);
 });
+
+test("PrototypeApi retrospective report exposes stable DTO with deterministic replay flag", async () => {
+  const bundle = await loadContentBundle(resolve(process.cwd(), "content/vertical-slice.json"));
+  const service = new GameService({ schoolYear: "Y10", contentBundle: bundle, rng: makeDeterministicRng(9) });
+  const api = new PrototypeApi(service);
+
+  api.submitChallengeOutcome({ topic: "ratio_proportion", correct: true, mode: "decision" });
+  api.advanceTime(4);
+  api.submitChallengeOutcome({ topic: "indices", correct: false, mode: "gate" });
+
+  const report = api.getRetrospectiveReport({ runId: "test-run", playerAlias: "qa" });
+
+  assert.equal(report.schemaVersion, "retrospective-v1");
+  assert.equal(report.leaderboardEntry.modelVersion, "legacy-v1");
+  assert.equal(report.leaderboardEntry.runId, "test-run");
+  assert.equal(report.leaderboardEntry.playerAlias, "qa");
+  assert.equal(typeof report.legacy.score, "number");
+  assert.equal(typeof report.summary.challengeStats.accuracy, "number");
+  assert.equal(typeof report.eventCounts.ChallengeAttempted, "number");
+  assert.equal(report.replay.deterministic, true);
+});

--- a/src/tests/retrospective.test.ts
+++ b/src/tests/retrospective.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildRetrospectiveReport } from "../application/retrospective.js";
+import { executeCommand } from "../domain/commands.js";
+import { createInitialGameState } from "../domain/state.js";
+
+test("retrospective report is deterministic for fixed event log and timestamp", () => {
+  let state = createInitialGameState("Y9");
+  state = executeCommand(state, { type: "change_role", role: "pps" });
+  state = executeCommand(state, { type: "submit_challenge_answer", topic: "percentages", correct: true, mode: "decision" });
+  state = executeCommand(state, { type: "advance_time", hours: 3 });
+  state = executeCommand(state, { type: "submit_challenge_answer", topic: "percentages", correct: false, mode: "crisis" });
+
+  const fixedNow = new Date("2026-03-31T12:00:00.000Z");
+  const reportA = buildRetrospectiveReport(state, { runId: "det-1", playerAlias: "tester", now: fixedNow });
+  const reportB = buildRetrospectiveReport(state, { runId: "det-1", playerAlias: "tester", now: fixedNow });
+
+  assert.deepEqual(reportA, reportB);
+  assert.equal(reportA.replay.deterministic, true);
+  assert.equal(reportA.eventCounts.ChallengeAttempted, 2);
+});
+
+test("legacy score model penalizes dark index escalation", () => {
+  let state = createInitialGameState("Y10");
+  state = executeCommand(state, { type: "submit_challenge_answer", topic: "ratio_proportion", correct: true, mode: "gate" });
+  const baseline = buildRetrospectiveReport(state, { now: new Date("2026-04-01T12:00:00.000Z") });
+
+  state = executeCommand(state, { type: "change_dark_index", delta: 30 });
+  const escalated = buildRetrospectiveReport(state, { now: new Date("2026-04-01T12:00:00.000Z") });
+
+  assert.equal(escalated.legacy.score < baseline.legacy.score, true);
+});


### PR DESCRIPTION
## Summary
- add retrospective/leaderboard model builder with deterministic replay consistency checks
- expose retrospective report DTO in Node and browser prototype APIs
- render retrospective panel in Tier 1 shell from live run state
- add tests and build docs for model + DTO stability
- update roadmap/status/next/backlog to reflect #22 closure and Phase 4 completion state

## Validation
- npm test
- npm run prototype:regression

## Issue
- Closes #22