### PR TITLE
Phase 5: retrospective/leaderboard multi-run polish (#30)

### DIFF
--- a/.build/RETROSPECTIVE_LEADERBOARD_MODEL.md
+++ b/.build/RETROSPECTIVE_LEADERBOARD_MODEL.md
@@ -56,4 +56,8 @@
 ## UI Binding
 - Prototype panel: `Retrospective`
   - shows run snapshot, legacy score/band, DTO stamp, replay status
+  - includes saved-run comparison controls and side-by-side latest-two run cards
   - files: `prototype/index.html`, `prototype/app.js`, `prototype/styles.css`
+
+## Multi-Run Extension
+- Comparison model and storage strategy are documented in `.build/RETROSPECTIVE_MULTI_RUN_MODEL.md`.

--- a/.build/RETROSPECTIVE_MULTI_RUN_MODEL.md
+++ b/.build/RETROSPECTIVE_MULTI_RUN_MODEL.md
@@ -1,0 +1,47 @@
+# Retrospective Multi-Run Model (Issue #30)
+
+## Goal
+- Support side-by-side comparison of saved retrospective runs with deterministic trend metrics.
+
+## Comparison DTO
+- Builder: `buildRetrospectiveComparison(...)` in `src/application/retrospective.ts`
+- Output schema: `retrospective-compare-v1`
+- Fields:
+  - `baselineRunId`, `candidateRunId`
+  - `runCount`
+  - `trends`
+    - `legacyScoreDelta`
+    - `challengeAccuracyDelta`
+    - `darkIndexDelta`
+    - `totalHoursDelta`
+  - `replay`
+    - `allDeterministic`
+    - `nonDeterministicRunIds`
+
+## Storage Strategy
+- Client storage key: `ttp.retrospectiveRuns.v1`
+- Storage medium: browser `localStorage`
+- Record shape:
+  - `savedAtIso`
+  - `report` (`RetrospectiveReport`)
+- Retention cap:
+  - keep latest 12 records (`MAX_SAVED_RETROSPECTIVE_RUNS`)
+- Safety:
+  - invalid/malformed stored entries are ignored on load
+  - persistence failures fall back to in-memory run list
+
+## UX Path
+- Controls in Retrospective panel:
+  - `Save this run`
+  - `Compare latest two`
+  - `Clear saved runs`
+- Comparison render:
+  - trend summary card
+  - baseline and candidate run cards side-by-side
+  - replay determinism status for compared runs
+
+## Regression Coverage
+- Domain/model tests:
+  - `src/tests/retrospective.test.ts` (comparison deltas + non-deterministic replay detection)
+- Shell rendering hooks:
+  - `src/tests/retrospective-multirun-hooks.test.ts`

--- a/dist/application/retrospective.js
+++ b/dist/application/retrospective.js
@@ -15,6 +15,10 @@ const EVENT_TYPES = [
     "NPCRelationshipChanged",
     "DarkIndexChanged"
 ];
+function toTimestamp(value) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
 function clampPercent(value) {
     return Math.max(0, Math.min(100, value));
 }
@@ -264,5 +268,35 @@ export function buildRetrospectiveReport(state, options = {}) {
             timestampIso: now.toISOString()
         },
         replay
+    };
+}
+export function buildRetrospectiveComparison(records) {
+    if (records.length < 2) {
+        throw new Error("At least two retrospective run records are required for comparison.");
+    }
+    const ordered = [...records].sort((left, right) => toTimestamp(left.savedAtIso) - toTimestamp(right.savedAtIso));
+    const baseline = ordered[ordered.length - 2];
+    const candidate = ordered[ordered.length - 1];
+    if (!baseline || !candidate) {
+        throw new Error("Unable to derive baseline/candidate runs for comparison.");
+    }
+    const nonDeterministicRunIds = ordered
+        .filter((entry) => !entry.report.replay.deterministic)
+        .map((entry) => entry.report.leaderboardEntry.runId);
+    return {
+        schemaVersion: "retrospective-compare-v1",
+        baselineRunId: baseline.report.leaderboardEntry.runId,
+        candidateRunId: candidate.report.leaderboardEntry.runId,
+        runCount: ordered.length,
+        trends: {
+            legacyScoreDelta: candidate.report.legacy.score - baseline.report.legacy.score,
+            challengeAccuracyDelta: candidate.report.summary.challengeStats.accuracy - baseline.report.summary.challengeStats.accuracy,
+            darkIndexDelta: candidate.report.summary.finalScores.darkIndex - baseline.report.summary.finalScores.darkIndex,
+            totalHoursDelta: candidate.report.summary.totalHours - baseline.report.summary.totalHours
+        },
+        replay: {
+            allDeterministic: nonDeterministicRunIds.length === 0,
+            nonDeterministicRunIds
+        }
     };
 }

--- a/dist/tests/retrospective-multirun-hooks.test.js
+++ b/dist/tests/retrospective-multirun-hooks.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+function includesAll(input, snippets) {
+    return snippets.every((snippet) => input.includes(snippet));
+}
+test("retrospective multi-run comparison hooks are present in shell markup and app flow", () => {
+    const html = readFileSync(resolve(process.cwd(), "prototype/index.html"), "utf8");
+    const appJs = readFileSync(resolve(process.cwd(), "prototype/app.js"), "utf8");
+    const requiredHtml = [
+        "id=\"save-run\"",
+        "id=\"compare-runs\"",
+        "id=\"clear-runs\"",
+        "id=\"comparison-summary\"",
+        "id=\"comparison-grid\""
+    ];
+    const requiredFlowHooks = [
+        "loadSavedRetrospectiveRuns(",
+        "persistSavedRetrospectiveRuns(",
+        "renderRunComparison(",
+        "saveCurrentRunSnapshot(",
+        "clearSavedRunSnapshots(",
+        "buildRetrospectiveComparison("
+    ];
+    assert.equal(includesAll(html, requiredHtml), true);
+    assert.equal(includesAll(appJs, requiredFlowHooks), true);
+});

--- a/dist/tests/retrospective.test.js
+++ b/dist/tests/retrospective.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildRetrospectiveReport, evaluateEndingState } from "../application/retrospective.js";
+import { buildRetrospectiveComparison, buildRetrospectiveReport, evaluateEndingState } from "../application/retrospective.js";
 import { executeCommand } from "../domain/commands.js";
 import { createInitialGameState } from "../domain/state.js";
 test("retrospective report is deterministic for fixed event log and timestamp", () => {
@@ -73,4 +73,42 @@ test("retrospective report includes ending taxonomy output", () => {
     assert.equal(report.summary.ending.outcome, "voted_out");
     assert.equal(typeof report.summary.ending.title, "string");
     assert.equal(typeof report.summary.ending.detail, "string");
+});
+test("multi-run comparison computes trend deltas from latest two saved runs", () => {
+    let stateA = createInitialGameState("Y10");
+    stateA = executeCommand(stateA, { type: "submit_challenge_answer", topic: "ratio_proportion", correct: true, mode: "decision" });
+    stateA = executeCommand(stateA, { type: "advance_time", hours: 4 });
+    const reportA = buildRetrospectiveReport(stateA, { runId: "run-a", now: new Date("2026-04-03T09:00:00.000Z") });
+    let stateB = createInitialGameState("Y10");
+    stateB = executeCommand(stateB, { type: "submit_challenge_answer", topic: "ratio_proportion", correct: false, mode: "crisis" });
+    stateB = executeCommand(stateB, { type: "change_dark_index", delta: 8 });
+    stateB = executeCommand(stateB, { type: "advance_time", hours: 8 });
+    const reportB = buildRetrospectiveReport(stateB, { runId: "run-b", now: new Date("2026-04-03T10:00:00.000Z") });
+    const comparison = buildRetrospectiveComparison([
+        { savedAtIso: "2026-04-03T09:00:00.000Z", report: reportA },
+        { savedAtIso: "2026-04-03T10:00:00.000Z", report: reportB }
+    ]);
+    assert.equal(comparison.schemaVersion, "retrospective-compare-v1");
+    assert.equal(comparison.baselineRunId, "run-a");
+    assert.equal(comparison.candidateRunId, "run-b");
+    assert.equal(typeof comparison.trends.legacyScoreDelta, "number");
+    assert.equal(comparison.replay.allDeterministic, true);
+});
+test("multi-run comparison reports non-deterministic replay runs", () => {
+    const stateA = createInitialGameState("Y9");
+    const reportA = buildRetrospectiveReport(stateA, { runId: "det-run", now: new Date("2026-04-03T09:00:00.000Z") });
+    const reportB = buildRetrospectiveReport(stateA, { runId: "nondet-run", now: new Date("2026-04-03T10:00:00.000Z") });
+    const modified = {
+        ...reportB,
+        replay: {
+            ...reportB.replay,
+            deterministic: false
+        }
+    };
+    const comparison = buildRetrospectiveComparison([
+        { savedAtIso: "2026-04-03T09:00:00.000Z", report: reportA },
+        { savedAtIso: "2026-04-03T10:00:00.000Z", report: modified }
+    ]);
+    assert.equal(comparison.replay.allDeterministic, false);
+    assert.deepEqual(comparison.replay.nonDeterministicRunIds, ["nondet-run"]);
 });

--- a/prototype/app.js
+++ b/prototype/app.js
@@ -1,4 +1,5 @@
 import { PrototypeApi } from "/prototype/runtime-api.js";
+import { buildRetrospectiveComparison } from "/dist/application/retrospective.js";
 import { validateContentBundle } from "/dist/content/schema.js";
 
 const summaryEntries = [
@@ -37,6 +38,11 @@ const elements = {
   audioToggle: document.querySelector("#audio-toggle"),
   cleanReadToggle: document.querySelector("#clean-read-toggle"),
   clockReadout: document.querySelector("#clock-readout"),
+  clearRuns: document.querySelector("#clear-runs"),
+  compareRuns: document.querySelector("#compare-runs"),
+  comparisonGrid: document.querySelector("#comparison-grid"),
+  comparisonStatus: document.querySelector("#comparison-status"),
+  comparisonSummary: document.querySelector("#comparison-summary"),
   diarySurface: document.querySelector("#diary-surface"),
   eventCount: document.querySelector("#event-count"),
   eventLog: document.querySelector("#event-log"),
@@ -70,6 +76,7 @@ const elements = {
   refresh: document.querySelector("#refresh"),
   restart: document.querySelector("#restart"),
   schoolYear: document.querySelector("#school-year"),
+  saveRun: document.querySelector("#save-run"),
   shellTier: document.querySelector("#shell-tier"),
   status: document.querySelector("#status"),
   summary: document.querySelector("#summary"),
@@ -156,6 +163,10 @@ let detailsVisible = false;
 let shellTier = "tier1";
 let whipQueueItems = [];
 let cabinetGridItems = [];
+let savedRetrospectiveRuns = [];
+
+const RETROSPECTIVE_RUN_STORAGE_KEY = "ttp.retrospectiveRuns.v1";
+const MAX_SAVED_RETROSPECTIVE_RUNS = 12;
 
 function setStatus(message) {
   elements.status.textContent = message;
@@ -165,6 +176,50 @@ function applyDetailsVisibility() {
   document.body.classList.toggle("details-expanded", detailsVisible);
   if (elements.detailsToggle) {
     elements.detailsToggle.textContent = detailsVisible ? "Hide extra panels" : "Show extra panels";
+  }
+}
+
+function formatDelta(value) {
+  if (value === 0) {
+    return "0";
+  }
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function loadSavedRetrospectiveRuns() {
+  try {
+    const raw = localStorage.getItem(RETROSPECTIVE_RUN_STORAGE_KEY);
+    if (!raw) {
+      savedRetrospectiveRuns = [];
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      savedRetrospectiveRuns = [];
+      return;
+    }
+    savedRetrospectiveRuns = parsed.filter((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return false;
+      }
+      if (typeof entry.savedAtIso !== "string") {
+        return false;
+      }
+      if (!entry.report || typeof entry.report !== "object") {
+        return false;
+      }
+      return typeof entry.report.schemaVersion === "string";
+    }).slice(-MAX_SAVED_RETROSPECTIVE_RUNS);
+  } catch {
+    savedRetrospectiveRuns = [];
+  }
+}
+
+function persistSavedRetrospectiveRuns() {
+  try {
+    localStorage.setItem(RETROSPECTIVE_RUN_STORAGE_KEY, JSON.stringify(savedRetrospectiveRuns));
+  } catch {
+    // Ignore persistence errors; in-memory run list still works.
   }
 }
 
@@ -994,6 +1049,114 @@ function renderRetrospective(report) {
   elements.retrospectiveStamp.textContent = report.replay.deterministic ? "deterministic replay" : "replay mismatch";
 }
 
+function renderRunComparison() {
+  if (elements.comparisonStatus) {
+    elements.comparisonStatus.textContent = `Saved runs: ${savedRetrospectiveRuns.length}`;
+  }
+  if (savedRetrospectiveRuns.length < 2) {
+    elements.comparisonSummary.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "Save at least two runs to compare trajectory shifts."
+      })
+    );
+    elements.comparisonGrid.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "No comparison available yet."
+      })
+    );
+    return;
+  }
+
+  const comparison = buildRetrospectiveComparison(savedRetrospectiveRuns);
+  const baseline = savedRetrospectiveRuns.find((entry) => entry.report.leaderboardEntry.runId === comparison.baselineRunId);
+  const candidate = savedRetrospectiveRuns.find((entry) => entry.report.leaderboardEntry.runId === comparison.candidateRunId);
+  if (!baseline || !candidate) {
+    elements.comparisonSummary.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "Comparison records are incomplete." })
+    );
+    elements.comparisonGrid.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "Unable to render run comparison." })
+    );
+    return;
+  }
+
+  const trendCard = document.createElement("article");
+  trendCard.className = "comparison-card";
+
+  const trendTitle = document.createElement("h3");
+  trendTitle.textContent = `Trend snapshot (${comparison.runCount} saved runs)`;
+
+  const trendList = document.createElement("ul");
+  const trendItems = [
+    `Legacy score delta: ${formatDelta(comparison.trends.legacyScoreDelta)}`,
+    `Accuracy delta: ${formatDelta(comparison.trends.challengeAccuracyDelta)}%`,
+    `Dark-index delta: ${formatDelta(comparison.trends.darkIndexDelta)}`,
+    `Hours delta: ${formatDelta(comparison.trends.totalHoursDelta)}`
+  ];
+  trendItems.forEach((text) => {
+    const item = document.createElement("li");
+    item.textContent = text;
+    trendList.append(item);
+  });
+
+  const replayMeta = document.createElement("p");
+  replayMeta.className = "meta";
+  replayMeta.textContent = comparison.replay.allDeterministic
+    ? "Comparison replay check: deterministic across compared runs."
+    : `Replay mismatches in run IDs: ${comparison.replay.nonDeterministicRunIds.join(", ")}`;
+
+  trendCard.append(trendTitle, trendList, replayMeta);
+  elements.comparisonSummary.replaceChildren(trendCard);
+
+  const makeRunCard = (label, entry) => {
+    const card = document.createElement("article");
+    card.className = "comparison-card";
+
+    const title = document.createElement("h3");
+    title.textContent = `${label}: ${entry.report.summary.finalRole.replaceAll("_", " ")}`;
+
+    const details = document.createElement("p");
+    details.textContent = `Legacy ${entry.report.legacy.score} | Accuracy ${entry.report.summary.challengeStats.accuracy}% | Dark index ${entry.report.summary.finalScores.darkIndex}`;
+
+    const meta = document.createElement("p");
+    meta.className = "meta";
+    meta.textContent = `${entry.report.leaderboardEntry.runId} | ${entry.savedAtIso}`;
+
+    card.append(title, details, meta);
+    return card;
+  };
+
+  elements.comparisonGrid.replaceChildren(
+    makeRunCard("Baseline", baseline),
+    makeRunCard("Candidate", candidate)
+  );
+}
+
+function saveCurrentRunSnapshot() {
+  if (!api) {
+    return;
+  }
+  const report = api.getRetrospectiveReport({
+    playerAlias: "prototype-shell",
+    runId: `shell-${Date.now()}`
+  });
+  const record = {
+    savedAtIso: new Date().toISOString(),
+    report
+  };
+  savedRetrospectiveRuns = [...savedRetrospectiveRuns, record].slice(-MAX_SAVED_RETROSPECTIVE_RUNS);
+  persistSavedRetrospectiveRuns();
+  renderRunComparison();
+  setStatus(`Saved run snapshot ${record.report.leaderboardEntry.runId}.`);
+}
+
+function clearSavedRunSnapshots() {
+  savedRetrospectiveRuns = [];
+  persistSavedRetrospectiveRuns();
+  renderRunComparison();
+  setStatus("Saved run snapshots cleared.");
+}
+
 function buildSection(title, body, meta) {
   const section = document.createElement("section");
   section.className = "packet-section";
@@ -1456,6 +1619,7 @@ function refreshPackets() {
   renderSummary(summary);
   renderProgression(progression);
   renderRetrospective(retrospective);
+  renderRunComparison();
   renderTrayState(trayState, currentPackets.length);
   renderPacketQueue();
   renderPacketFocus();
@@ -1589,6 +1753,22 @@ function wireEvents() {
   elements.refresh.addEventListener("click", () => {
     refreshPackets();
   });
+  if (elements.saveRun) {
+    elements.saveRun.addEventListener("click", () => {
+      saveCurrentRunSnapshot();
+    });
+  }
+  if (elements.compareRuns) {
+    elements.compareRuns.addEventListener("click", () => {
+      renderRunComparison();
+      setStatus("Compared latest saved runs.");
+    });
+  }
+  if (elements.clearRuns) {
+    elements.clearRuns.addEventListener("click", () => {
+      clearSavedRunSnapshots();
+    });
+  }
 
   if (elements.shellTier) {
     elements.shellTier.addEventListener("change", () => {
@@ -1708,6 +1888,7 @@ function wireEvents() {
 }
 
 loadAccessibilityModes();
+loadSavedRetrospectiveRuns();
 applyDetailsVisibility();
 setShellTier("tier1");
 wireEvents();

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -184,11 +184,23 @@
             <h2>Retrospective</h2>
             <span id="retrospective-stamp" class="meta"></span>
           </div>
+          <div class="retrospective-actions">
+            <button id="save-run" type="button">Save this run</button>
+            <button id="compare-runs" type="button">Compare latest two</button>
+            <button id="clear-runs" type="button">Clear saved runs</button>
+          </div>
+          <p id="comparison-status" class="meta">Saved runs: 0</p>
           <div id="retrospective-summary" class="retrospective-summary">
             <p>Retrospective snapshot will appear after your first actions.</p>
           </div>
           <div id="leaderboard-summary" class="leaderboard-summary">
             <p>Legacy score and leaderboard entry are not available yet.</p>
+          </div>
+          <div id="comparison-summary" class="comparison-summary">
+            <p>Save at least two runs to compare trajectory shifts.</p>
+          </div>
+          <div id="comparison-grid" class="comparison-grid">
+            <p>No comparison available yet.</p>
           </div>
         </article>
 

--- a/prototype/styles.css
+++ b/prototype/styles.css
@@ -337,6 +337,20 @@ h1 {
   padding: 0.56rem 0.82rem;
 }
 
+.retrospective-actions {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  margin: 0.5rem 0 0.55rem;
+}
+
+.retrospective-actions button {
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, #fff 0%, #f1e8d7 100%);
+  border-radius: 999px;
+  padding: 0.45rem 0.72rem;
+}
+
 .tier2-only {
   display: none;
 }
@@ -696,6 +710,17 @@ body:not(.details-expanded) #supplement-surface {
   gap: 0.55rem;
 }
 
+.comparison-summary,
+.comparison-grid {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 0.55rem;
+}
+
+.comparison-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .record-stat {
   border: 1px solid var(--line);
   border-radius: 10px;
@@ -799,6 +824,24 @@ body:not(.details-expanded) #supplement-surface {
   padding: 0.6rem 0.7rem;
 }
 
+.comparison-card {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.6rem 0.7rem;
+}
+
+.comparison-card p,
+.comparison-card li {
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+.comparison-card ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1rem;
+}
+
 .whip-item {
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -895,6 +938,10 @@ body:not(.details-expanded) #supplement-surface {
   }
 
   .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .comparison-grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/application/retrospective.ts
+++ b/src/application/retrospective.ts
@@ -87,12 +87,39 @@ export interface RetrospectiveReport {
   replay: ReplayConsistency;
 }
 
+export interface RetrospectiveRunRecord {
+  savedAtIso: string;
+  report: RetrospectiveReport;
+}
+
+export interface RetrospectiveComparison {
+  schemaVersion: "retrospective-compare-v1";
+  baselineRunId: string;
+  candidateRunId: string;
+  runCount: number;
+  trends: {
+    legacyScoreDelta: number;
+    challengeAccuracyDelta: number;
+    darkIndexDelta: number;
+    totalHoursDelta: number;
+  };
+  replay: {
+    allDeterministic: boolean;
+    nonDeterministicRunIds: string[];
+  };
+}
+
 export interface BuildRetrospectiveOptions {
   runId?: string;
   playerAlias?: string;
   seedState?: GameState;
   rng?: Rng;
   now?: Date;
+}
+
+function toTimestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function clampPercent(value: number): number {
@@ -377,5 +404,39 @@ export function buildRetrospectiveReport(state: GameState, options: BuildRetrosp
       timestampIso: now.toISOString()
     },
     replay
+  };
+}
+
+export function buildRetrospectiveComparison(records: RetrospectiveRunRecord[]): RetrospectiveComparison {
+  if (records.length < 2) {
+    throw new Error("At least two retrospective run records are required for comparison.");
+  }
+
+  const ordered = [...records].sort((left, right) => toTimestamp(left.savedAtIso) - toTimestamp(right.savedAtIso));
+  const baseline = ordered[ordered.length - 2];
+  const candidate = ordered[ordered.length - 1];
+  if (!baseline || !candidate) {
+    throw new Error("Unable to derive baseline/candidate runs for comparison.");
+  }
+
+  const nonDeterministicRunIds = ordered
+    .filter((entry) => !entry.report.replay.deterministic)
+    .map((entry) => entry.report.leaderboardEntry.runId);
+
+  return {
+    schemaVersion: "retrospective-compare-v1",
+    baselineRunId: baseline.report.leaderboardEntry.runId,
+    candidateRunId: candidate.report.leaderboardEntry.runId,
+    runCount: ordered.length,
+    trends: {
+      legacyScoreDelta: candidate.report.legacy.score - baseline.report.legacy.score,
+      challengeAccuracyDelta: candidate.report.summary.challengeStats.accuracy - baseline.report.summary.challengeStats.accuracy,
+      darkIndexDelta: candidate.report.summary.finalScores.darkIndex - baseline.report.summary.finalScores.darkIndex,
+      totalHoursDelta: candidate.report.summary.totalHours - baseline.report.summary.totalHours
+    },
+    replay: {
+      allDeterministic: nonDeterministicRunIds.length === 0,
+      nonDeterministicRunIds
+    }
   };
 }

--- a/src/tests/retrospective-multirun-hooks.test.ts
+++ b/src/tests/retrospective-multirun-hooks.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+function includesAll(input: string, snippets: string[]): boolean {
+  return snippets.every((snippet) => input.includes(snippet));
+}
+
+test("retrospective multi-run comparison hooks are present in shell markup and app flow", () => {
+  const html = readFileSync(resolve(process.cwd(), "prototype/index.html"), "utf8");
+  const appJs = readFileSync(resolve(process.cwd(), "prototype/app.js"), "utf8");
+
+  const requiredHtml = [
+    "id=\"save-run\"",
+    "id=\"compare-runs\"",
+    "id=\"clear-runs\"",
+    "id=\"comparison-summary\"",
+    "id=\"comparison-grid\""
+  ];
+  const requiredFlowHooks = [
+    "loadSavedRetrospectiveRuns(",
+    "persistSavedRetrospectiveRuns(",
+    "renderRunComparison(",
+    "saveCurrentRunSnapshot(",
+    "clearSavedRunSnapshots(",
+    "buildRetrospectiveComparison("
+  ];
+
+  assert.equal(includesAll(html, requiredHtml), true);
+  assert.equal(includesAll(appJs, requiredFlowHooks), true);
+});

--- a/src/tests/retrospective.test.ts
+++ b/src/tests/retrospective.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildRetrospectiveReport, evaluateEndingState } from "../application/retrospective.js";
+import { buildRetrospectiveComparison, buildRetrospectiveReport, evaluateEndingState } from "../application/retrospective.js";
 import { executeCommand } from "../domain/commands.js";
 import { createInitialGameState } from "../domain/state.js";
 
@@ -91,4 +91,49 @@ test("retrospective report includes ending taxonomy output", () => {
   assert.equal(report.summary.ending.outcome, "voted_out");
   assert.equal(typeof report.summary.ending.title, "string");
   assert.equal(typeof report.summary.ending.detail, "string");
+});
+
+test("multi-run comparison computes trend deltas from latest two saved runs", () => {
+  let stateA = createInitialGameState("Y10");
+  stateA = executeCommand(stateA, { type: "submit_challenge_answer", topic: "ratio_proportion", correct: true, mode: "decision" });
+  stateA = executeCommand(stateA, { type: "advance_time", hours: 4 });
+  const reportA = buildRetrospectiveReport(stateA, { runId: "run-a", now: new Date("2026-04-03T09:00:00.000Z") });
+
+  let stateB = createInitialGameState("Y10");
+  stateB = executeCommand(stateB, { type: "submit_challenge_answer", topic: "ratio_proportion", correct: false, mode: "crisis" });
+  stateB = executeCommand(stateB, { type: "change_dark_index", delta: 8 });
+  stateB = executeCommand(stateB, { type: "advance_time", hours: 8 });
+  const reportB = buildRetrospectiveReport(stateB, { runId: "run-b", now: new Date("2026-04-03T10:00:00.000Z") });
+
+  const comparison = buildRetrospectiveComparison([
+    { savedAtIso: "2026-04-03T09:00:00.000Z", report: reportA },
+    { savedAtIso: "2026-04-03T10:00:00.000Z", report: reportB }
+  ]);
+
+  assert.equal(comparison.schemaVersion, "retrospective-compare-v1");
+  assert.equal(comparison.baselineRunId, "run-a");
+  assert.equal(comparison.candidateRunId, "run-b");
+  assert.equal(typeof comparison.trends.legacyScoreDelta, "number");
+  assert.equal(comparison.replay.allDeterministic, true);
+});
+
+test("multi-run comparison reports non-deterministic replay runs", () => {
+  const stateA = createInitialGameState("Y9");
+  const reportA = buildRetrospectiveReport(stateA, { runId: "det-run", now: new Date("2026-04-03T09:00:00.000Z") });
+  const reportB = buildRetrospectiveReport(stateA, { runId: "nondet-run", now: new Date("2026-04-03T10:00:00.000Z") });
+  const modified = {
+    ...reportB,
+    replay: {
+      ...reportB.replay,
+      deterministic: false
+    }
+  };
+
+  const comparison = buildRetrospectiveComparison([
+    { savedAtIso: "2026-04-03T09:00:00.000Z", report: reportA },
+    { savedAtIso: "2026-04-03T10:00:00.000Z", report: modified }
+  ]);
+
+  assert.equal(comparison.replay.allDeterministic, false);
+  assert.deepEqual(comparison.replay.nonDeterministicRunIds, ["nondet-run"]);
 });


### PR DESCRIPTION
## Summary
- add shared multi-run comparison DTO/model (`retrospective-compare-v1`) with deterministic replay status
- implement localStorage-backed saved-run strategy in prototype shell (`ttp.retrospectiveRuns.v1`)
- add Retrospective panel controls: save run, compare latest two, clear runs
- render side-by-side baseline/candidate run cards plus trend deltas (legacy score, accuracy, dark index, hours)
- add domain and shell hook regression tests for multi-run comparison path
- document multi-run model and storage strategy

## Validation
- npm test
- npm run prototype:regression

## Issue
- Closes #30