### PR TITLE
Prototype: player-first UX baseline and copy polish for Tier 1 playtests

### DIFF
--- a/prototype/app.js
+++ b/prototype/app.js
@@ -370,7 +370,11 @@ function buildSmartphoneBatch(action, summary, deltas, isUrgent) {
   const updates = [];
 
   if (action.response.warnings.length > 0) {
-    updates.push(...action.response.warnings.map((warning) => `warning:${warning.code}`));
+    if (DEBUG_MODE) {
+      updates.push(...action.response.warnings.map((warning) => `warning:${warning.code}`));
+    } else {
+      updates.push("Urgent warning received");
+    }
   }
 
   if (deltas.publicApproval !== 0) {
@@ -383,10 +387,10 @@ function buildSmartphoneBatch(action, summary, deltas, isUrgent) {
     updates.push(`dark index ${signedDelta(deltas.darkIndex)}`);
   }
   if (updates.length === 0 && action.response.events.length > 0) {
-    updates.push(`events:${action.response.events.length} routed`);
+    updates.push(DEBUG_MODE ? `events:${action.response.events.length} routed` : "Outcome updates received");
   }
   if (updates.length === 0) {
-    updates.push("no measurable fallout movement");
+    updates.push(DEBUG_MODE ? "no measurable fallout movement" : "No major change yet");
   }
 
   falloutBatchCounter += 1;
@@ -524,7 +528,7 @@ function renderFalloutSurfaces() {
 
   if (smartphoneBatches.length === 0) {
     elements.phoneBatches.replaceChildren(
-      Object.assign(document.createElement("p"), { textContent: "No fallout updates queued yet." })
+      Object.assign(document.createElement("p"), { textContent: "No new consequences yet." })
     );
   } else {
     elements.phoneBatches.replaceChildren(
@@ -694,21 +698,21 @@ function summarizeEventForPlayer(event) {
         ? "Answer submitted correctly."
         : "Answer submitted incorrectly.";
     case "ChallengeSucceeded":
-      return "Challenge passed. Confidence improves.";
+      return "Answer accepted.";
     case "ChallengeFailed":
-      return "Challenge missed. Consequences applied.";
+      return "Answer missed.";
     case "TimeAdvanced":
       return `Time advanced by ${event.payload.hours}h.`;
     case "TempoChanged":
       return `Tempo shifted to ${formatTempo(event.payload.tempo)}.`;
     case "RoleChanged":
-      return "Role updated.";
+      return "Role changed.";
     case "RemediationAssigned":
       return "Remediation task assigned.";
     case "TimedChallengeStarted":
-      return "Timed challenge has started.";
+      return "Timed task started.";
     case "TimedChallengeExpired":
-      return "Timed challenge expired.";
+      return "Timed task expired.";
     default:
       return "State updated.";
   }
@@ -718,9 +722,7 @@ function renderActionResult() {
   if (!lastAction) {
     elements.actionType.textContent = "none yet";
     elements.actionResult.replaceChildren(
-      Object.assign(document.createElement("p"), {
-        textContent: "No challenge outcome or time advance has been submitted yet."
-      })
+      Object.assign(document.createElement("p"), { textContent: "No action taken yet." })
     );
     elements.eventCount.textContent = "0 emitted";
     elements.eventLog.replaceChildren(
@@ -740,11 +742,13 @@ function renderActionResult() {
   heading.textContent = lastAction.heading;
 
   const summary = document.createElement("p");
-  summary.textContent = `${formatTempo(lastAction.response.summary.currentTempo)} at ${lastAction.response.summary.timeHours}h after ${lastAction.response.events.length} event${lastAction.response.events.length === 1 ? "" : "s"}.`;
+  summary.textContent = DEBUG_MODE
+    ? `${formatTempo(lastAction.response.summary.currentTempo)} at ${lastAction.response.summary.timeHours}h after ${lastAction.response.events.length} event${lastAction.response.events.length === 1 ? "" : "s"}.`
+    : `${lastAction.response.events.length} update${lastAction.response.events.length === 1 ? "" : "s"} applied.`;
 
   actionCard.append(heading, summary);
 
-  if (lastAction.response.warnings.length > 0) {
+  if (DEBUG_MODE && lastAction.response.warnings.length > 0) {
     const warnings = document.createElement("p");
     warnings.textContent = `Warnings: ${lastAction.response.warnings.map((warning) => warning.code).join(", ")}`;
     actionCard.append(warnings);
@@ -755,7 +759,7 @@ function renderActionResult() {
   elements.eventCount.textContent = `${lastAction.response.events.length} emitted`;
   if (lastAction.response.events.length === 0) {
     elements.eventLog.replaceChildren(
-      Object.assign(document.createElement("p"), { textContent: "Action emitted no events." })
+      Object.assign(document.createElement("p"), { textContent: "No visible update from the last action." })
     );
     return;
   }
@@ -801,7 +805,10 @@ function handleChallengeOutcome(packet, correct, numericAnswer) {
   };
   applyFalloutRouting(lastAction);
   refreshPackets();
-  setStatus(`Submitted ${packet.challenge.topic} as ${correct ? "correct" : "incorrect"}${answerSnippet}.`);
+  setStatus(DEBUG_MODE
+    ? `Submitted ${packet.challenge.topic} as ${correct ? "correct" : "incorrect"}${answerSnippet}.`
+    : (correct ? "Answer submitted. Marked correct." : "Answer submitted. Marked incorrect.")
+  );
 }
 
 function handleAdvanceTime() {
@@ -829,11 +836,11 @@ function handleAdvanceTime() {
 
 function renderTrayState(state, packetCount) {
   elements.trayState.textContent = state;
-  elements.packetCount.textContent = `${packetCount} packet${packetCount === 1 ? "" : "s"} in queue`;
+  elements.packetCount.textContent = `${packetCount} brief${packetCount === 1 ? "" : "s"} waiting`;
   elements.openNext.disabled = packetCount === 0;
   elements.trayAnchor.setAttribute(
     "aria-label",
-    `In-Tray ${state}. ${packetCount} packet${packetCount === 1 ? "" : "s"} available.`
+    `In-Tray ${state}. ${packetCount} brief${packetCount === 1 ? "" : "s"} available.`
   );
 }
 
@@ -847,14 +854,14 @@ function renderPacket(packet, index) {
 
   const kicker = document.createElement("p");
   kicker.className = "doc-kicker";
-  kicker.textContent = isCrisisVariant ? "Crisis packet" : "Event/Decision brief";
+  kicker.textContent = isCrisisVariant ? "Urgent brief" : "Brief";
   article.append(kicker);
 
   const header = document.createElement("div");
   header.className = "packet-header";
 
   const title = document.createElement("h3");
-  title.textContent = packet.eventCard?.title ?? `Packet ${index + 1}`;
+  title.textContent = packet.eventCard?.title ?? `Brief ${index + 1}`;
 
   const badge = document.createElement("span");
   badge.className = "badge";
@@ -869,7 +876,12 @@ function renderPacket(packet, index) {
     const timer = packet.challenge.timed && packet.challenge.timerSeconds
       ? `Timed: ${packet.challenge.timerSeconds}s`
       : `Mode: ${packet.challenge.mode}`;
-    article.append(buildSection("Decision task", packet.challenge.prompt, `${packet.challenge.topic} | ${timer}`));
+    const taskMeta = DEBUG_MODE
+      ? `${packet.challenge.topic} | ${timer}`
+      : packet.challenge.timed && packet.challenge.timerSeconds
+        ? `Timed task: ${packet.challenge.timerSeconds}s`
+        : "Standard task";
+    article.append(buildSection("Decision task", packet.challenge.prompt, taskMeta));
 
     const form = document.createElement("form");
     form.className = "challenge-form";
@@ -939,7 +951,7 @@ function renderPacket(packet, index) {
         correct = resolveChallengeCorrectness(packet, answerInput.value);
       }
       if (correct === undefined) {
-        setStatus("Could not grade this answer automatically. Use debug mode to force outcome if needed.");
+        setStatus("Couldn't grade that answer. Try a standard numeric format.");
         return;
       }
       handleChallengeOutcome(packet, correct, answerInput.value);
@@ -973,7 +985,7 @@ function renderPacketFocus() {
     elements.packetFullscreenToggle.disabled = true;
     elements.packetFocus.replaceChildren(
       Object.assign(document.createElement("p"), {
-        textContent: "No active packet selected. Open the tray to pull the next packet into focus."
+        textContent: "No brief open. Use In-Tray to open the next brief."
       })
     );
     elements.packetFocus.removeAttribute("aria-label");
@@ -1017,7 +1029,7 @@ function renderPacketQueue() {
       const button = document.createElement("button");
       button.type = "button";
       button.className = `queue-item${index === activePacketIndex ? " active" : ""}`;
-      button.textContent = packet.eventCard?.title ?? `Packet ${index + 1}`;
+      button.textContent = packet.eventCard?.title ?? `Brief ${index + 1}`;
       button.addEventListener("click", () => {
         setActivePacket(index);
       });
@@ -1056,7 +1068,7 @@ function renderNextAction(trayState) {
 
 function openNextPacketFromTray() {
   if (currentPackets.length === 0) {
-    setStatus("In-Tray is idle. No packet available to open.");
+    setStatus("In-Tray is clear. Advance time for the next brief.");
     return;
   }
 
@@ -1065,7 +1077,7 @@ function openNextPacketFromTray() {
   if (isNarrowViewport()) {
     setPacketFullscreen(true);
   }
-  setStatus(`Opened packet ${nextIndex + 1} from In-Tray.`);
+  setStatus(`Opened brief ${nextIndex + 1} from In-Tray.`);
 }
 
 function findPrimaryTaskTarget() {
@@ -1096,20 +1108,20 @@ function maybeRenderInterrupt(summary, trayState) {
     elements.interruptBody.textContent = top.detail;
   } else if (urgentFallout) {
     elements.interruptTitle.textContent = "Urgent fallout alert";
-    elements.interruptBody.textContent = "High-priority consequences were routed to Smartphone. Use return to continue the active packet path.";
+    elements.interruptBody.textContent = "High-priority consequences need attention. Use return to continue your current brief.";
   } else {
     elements.interruptTitle.textContent = `${formatTempo(summary.currentTempo)} pressure state`;
-    elements.interruptBody.textContent = "Urgent state is active. Use In-Tray or active packet to clear priority work.";
+    elements.interruptBody.textContent = "Urgency is high. Use In-Tray or your current brief to clear priority work.";
   }
   elements.interruptDismiss.onclick = () => {
     dismissedInterruptKey = interruptKey;
     elements.interrupt.classList.add("hidden");
-    setStatus("Urgent interruption acknowledged. Priority controls remain available.");
+    setStatus("Urgent alert acknowledged.");
   };
   elements.interruptReturn.onclick = () => {
     const target = findPrimaryTaskTarget();
     target.focus();
-    setStatus("Returned to highest-priority task path.");
+    setStatus("Returned to the main task.");
   };
 }
 
@@ -1164,7 +1176,7 @@ function refreshPackets() {
   }
 
   elements.focusOrderStamp.textContent = SURFACE_FOCUS_ORDER.join(" -> ");
-  setStatus(DEBUG_MODE ? `Tier 1 shell rendered. Tray state: ${trayState}.` : "Desk updated.");
+  setStatus(DEBUG_MODE ? `Tier 1 shell rendered. Tray state: ${trayState}.` : "Ready.");
 }
 
 function focusSurface(surface) {
@@ -1189,7 +1201,7 @@ async function loadBundle() {
 }
 
 async function boot() {
-  setStatus("Loading vertical slice content…");
+  setStatus("Loading briefing content…");
   const bundle = await loadBundle();
   lastAction = null;
   dismissedInterruptKey = null;
@@ -1223,11 +1235,11 @@ function wireEvents() {
   });
   elements.packetFullscreenToggle.addEventListener("click", () => {
     setPacketFullscreen(true);
-    setStatus("Packet switched to fullscreen view.");
+    setStatus("Brief opened in fullscreen.");
   });
   elements.packetFullscreenClose.addEventListener("click", () => {
     setPacketFullscreen(false);
-    setStatus("Returned from fullscreen packet view.");
+    setStatus("Exited fullscreen.");
   });
   elements.audioToggle.addEventListener("click", () => {
     audioEnabled = !audioEnabled;
@@ -1279,19 +1291,19 @@ function wireEvents() {
 
   elements.phoneAnchor.addEventListener("click", () => {
     focusSurface(elements.phoneSurface);
-    setStatus("Smartphone anchor opened immediate fallout surface.");
+    setStatus("Opened latest consequences.");
   });
   elements.recordAnchor.addEventListener("click", () => {
     focusSurface(elements.recordSurface);
-    setStatus("The Record anchor opened official summary surface.");
+    setStatus("Opened public briefing.");
   });
   elements.bubbleAnchor.addEventListener("click", () => {
     focusSurface(elements.bubbleSurface);
-    setStatus("The Bubble anchor opened narrative event wire.");
+    setStatus("Opened outcome log.");
   });
   elements.supplementAnchor.addEventListener("click", () => {
     focusSurface(elements.supplementSurface);
-    setStatus("The Supplement anchor opened optional enrichment surface.");
+    setStatus("Opened background briefings.");
   });
   elements.lampAnchor.addEventListener("click", () => {
     setStatus("Lamp fallback activated. Save/Quit action remains available through explicit controls.");
@@ -1305,7 +1317,7 @@ function wireEvents() {
 
     if (event.key === "Escape" && packetFullscreen) {
       setPacketFullscreen(false);
-      setStatus("Exited fullscreen packet view with Escape.");
+      setStatus("Exited fullscreen.");
       return;
     }
 

--- a/prototype/app.js
+++ b/prototype/app.js
@@ -1,0 +1,1354 @@
+import { PrototypeApi } from "/dist/application/prototype-api.js";
+import { validateContentBundle } from "/dist/content/schema.js";
+
+const DEBUG_MODE = new URLSearchParams(window.location.search).get("debug") === "1";
+
+const summaryEntries = [
+  ["School year", "schoolYear"],
+  ["Role", "currentRole"],
+  ["Tempo", "currentTempo"],
+  ["Time", "timeHours"],
+  ["Party loyalty", "partyLoyaltyScore"],
+  ["Public approval", "publicApproval"],
+  ["Constituency", "constituencyApproval"],
+  ["Press", "pressRelationship"],
+  ["Dark index", "darkIndex"],
+  ["Remediations", "pendingRemediations"],
+  ["Timed challenges", "activeTimedChallenges"],
+  ["Event log", "eventLogEntries"]
+];
+
+const elements = {
+  actionResult: document.querySelector("#action-result"),
+  actionType: document.querySelector("#action-type"),
+  advance: document.querySelector("#advance"),
+  advanceHours: document.querySelector("#advance-hours"),
+  bubbleAnchor: document.querySelector("#bubble-anchor"),
+  bubbleLead: document.querySelector("#bubble-lead"),
+  bubbleSurface: document.querySelector("#bubble-surface"),
+  collisionQueue: document.querySelector("#collision-queue"),
+  collisionStamp: document.querySelector("#collision-stamp"),
+  collisionSurface: document.querySelector("#collision-surface"),
+  audioState: document.querySelector("#audio-state"),
+  audioToggle: document.querySelector("#audio-toggle"),
+  cleanReadToggle: document.querySelector("#clean-read-toggle"),
+  clockReadout: document.querySelector("#clock-readout"),
+  diarySurface: document.querySelector("#diary-surface"),
+  eventCount: document.querySelector("#event-count"),
+  eventLog: document.querySelector("#event-log"),
+  focusOrderStamp: document.querySelector("#focus-order-stamp"),
+  interrupt: document.querySelector("#interrupt"),
+  interruptBody: document.querySelector("#interrupt-body"),
+  interruptDismiss: document.querySelector("#interrupt-dismiss"),
+  interruptReturn: document.querySelector("#interrupt-return"),
+  interruptTitle: document.querySelector("#interrupt-title"),
+  lampAnchor: document.querySelector("#lamp-anchor"),
+  nextAction: document.querySelector("#next-action"),
+  openNext: document.querySelector("#open-next"),
+  packetCount: document.querySelector("#packet-count"),
+  packetFullscreenClose: document.querySelector("#packet-fullscreen-close"),
+  packetFullscreenToggle: document.querySelector("#packet-fullscreen-toggle"),
+  packetFocus: document.querySelector("#packet-focus"),
+  packets: document.querySelector("#packets"),
+  phoneBatches: document.querySelector("#phone-batches"),
+  phoneAnchor: document.querySelector("#phone-anchor"),
+  phoneSurface: document.querySelector("#phone-surface"),
+  progression: document.querySelector("#progression"),
+  promotionStamp: document.querySelector("#promotion-stamp"),
+  recordAnchor: document.querySelector("#record-anchor"),
+  recordStat: document.querySelector("#record-stat"),
+  recordSurface: document.querySelector("#record-surface"),
+  reducedMotionToggle: document.querySelector("#reduced-motion-toggle"),
+  refresh: document.querySelector("#refresh"),
+  restart: document.querySelector("#restart"),
+  schoolYear: document.querySelector("#school-year"),
+  status: document.querySelector("#status"),
+  summary: document.querySelector("#summary"),
+  summaryStamp: document.querySelector("#summary-stamp"),
+  supplementList: document.querySelector("#supplement-list"),
+  supplementAnchor: document.querySelector("#supplement-anchor"),
+  supplementStamp: document.querySelector("#supplement-stamp"),
+  supplementSurface: document.querySelector("#supplement-surface"),
+  tempoState: document.querySelector("#tempo-state"),
+  trayAnchor: document.querySelector("#tray-anchor"),
+  trayState: document.querySelector("#tray-state")
+};
+
+const SURFACE_FOCUS_ORDER = [
+  "In-Tray",
+  "Active packet",
+  "Smartphone",
+  "The Record",
+  "The Bubble",
+  "The Supplement",
+  "Diary"
+];
+
+const URGENT_TEMPOS = new Set(["crisis", "media_storm"]);
+const TEMPO_PROFILES = {
+  recess: { visibleBatches: 2, updatesPerBatch: 2, audioFrequency: 220, pressureClass: "recess" },
+  parliamentary: { visibleBatches: 3, updatesPerBatch: 3, audioFrequency: 260, pressureClass: "parliamentary" },
+  crisis: { visibleBatches: 5, updatesPerBatch: 4, audioFrequency: 330, pressureClass: "crisis" },
+  media_storm: { visibleBatches: 6, updatesPerBatch: 5, audioFrequency: 390, pressureClass: "media_storm" }
+};
+const COLLISION_PRIORITY = {
+  crisis_interrupt: 1,
+  timed_challenge: 2,
+  packet_resolution: 3,
+  fallout_updates: 4,
+  flavour_updates: 5
+};
+
+let api;
+let currentPackets = [];
+let activePacketIndex = -1;
+let lastAction = null;
+let dismissedInterruptKey = null;
+let latestSummary = null;
+let packetFullscreen = false;
+let falloutBatchCounter = 0;
+let smartphoneBatches = [];
+let recordLens = null;
+let bubbleShadowLead = null;
+let supplementItems = [];
+let collisionQueueItems = [];
+let audioEnabled = false;
+let audioContext = null;
+let lastTempoForCue = null;
+let lastCollisionCueKey = "";
+let cleanReadEnabled = false;
+let reducedMotionEnabled = false;
+let challengeAnswerById = new Map();
+
+function applyDebugMode() {
+  document.body.classList.toggle("debug-mode", DEBUG_MODE);
+  const debugOnly = document.querySelectorAll(".debug-only");
+  debugOnly.forEach((element) => {
+    if (DEBUG_MODE) {
+      element.removeAttribute("hidden");
+    } else {
+      element.setAttribute("hidden", "hidden");
+    }
+  });
+}
+
+function setStatus(message) {
+  elements.status.textContent = message;
+}
+
+function resolveChallengeCorrectness(packet, numericAnswer) {
+  const raw = String(numericAnswer).trim();
+  const submitted = Number.parseFloat(raw);
+  const expected = challengeAnswerById.get(packet.challenge?.id);
+
+  if (!Number.isFinite(submitted)) {
+    return undefined;
+  }
+  if (!Number.isFinite(expected)) {
+    return undefined;
+  }
+
+  return Math.abs(submitted - expected) <= 0.000001;
+}
+
+function formatTempo(tempo) {
+  return String(tempo).replaceAll("_", " ");
+}
+
+function computeTrayState(summary, packets) {
+  if (packets.length === 0) {
+    return "idle";
+  }
+  const hasTimedPacket = packets.some((packet) => Boolean(packet.challenge?.timed));
+  if (URGENT_TEMPOS.has(summary.currentTempo) || hasTimedPacket) {
+    return "urgent";
+  }
+  return "available";
+}
+
+function isNarrowViewport() {
+  return window.matchMedia("(max-width: 820px)").matches;
+}
+
+function setPacketFullscreen(nextState) {
+  packetFullscreen = nextState;
+  document.body.classList.toggle("packet-fullscreen", packetFullscreen);
+  elements.packetFullscreenClose.classList.toggle("hidden", !packetFullscreen);
+  elements.packetFullscreenToggle.classList.toggle("hidden", packetFullscreen);
+}
+
+function applyAccessibilityModes() {
+  document.body.classList.toggle("clean-read", cleanReadEnabled);
+  document.body.classList.toggle("reduced-motion", reducedMotionEnabled);
+  if (elements.cleanReadToggle) {
+    elements.cleanReadToggle.checked = cleanReadEnabled;
+  }
+  if (elements.reducedMotionToggle) {
+    elements.reducedMotionToggle.checked = reducedMotionEnabled;
+  }
+}
+
+function persistAccessibilityModes() {
+  try {
+    localStorage.setItem("ttp.cleanRead", cleanReadEnabled ? "1" : "0");
+    localStorage.setItem("ttp.reducedMotion", reducedMotionEnabled ? "1" : "0");
+  } catch {
+    // Ignore persistence failures; runtime mode still applies.
+  }
+}
+
+function loadAccessibilityModes() {
+  try {
+    cleanReadEnabled = localStorage.getItem("ttp.cleanRead") === "1";
+    reducedMotionEnabled = localStorage.getItem("ttp.reducedMotion") === "1";
+  } catch {
+    cleanReadEnabled = false;
+    reducedMotionEnabled = false;
+  }
+  applyAccessibilityModes();
+}
+
+function getTempoProfile(tempo) {
+  return TEMPO_PROFILES[tempo] ?? TEMPO_PROFILES.parliamentary;
+}
+
+function setTempoVisualState(tempo) {
+  const tempoClasses = Object.keys(TEMPO_PROFILES).map((entry) => `tempo-${entry}`);
+  document.body.classList.remove(...tempoClasses);
+  document.body.classList.add(`tempo-${tempo}`);
+  elements.tempoState.textContent = `${formatTempo(tempo)} pressure`;
+}
+
+function ensureAudioContext() {
+  if (audioContext) {
+    return audioContext;
+  }
+  const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContextCtor) {
+    return null;
+  }
+  audioContext = new AudioContextCtor();
+  return audioContext;
+}
+
+function playPressureCue(summary, reasonKey) {
+  const profile = getTempoProfile(summary.currentTempo);
+  const cueLabel = DEBUG_MODE
+    ? `cue:${formatTempo(summary.currentTempo)}:${reasonKey}`
+    : "Pressure cue";
+  const fallbackLabel = DEBUG_MODE
+    ? `${cueLabel} (visual fallback active)`
+    : "Visual urgency cues active";
+
+  if (!audioEnabled) {
+    elements.audioState.textContent = fallbackLabel;
+    return;
+  }
+
+  const ctx = ensureAudioContext();
+  if (!ctx) {
+    elements.audioState.textContent = `${fallbackLabel} (audio context unavailable)`;
+    return;
+  }
+  if (ctx.state === "suspended") {
+    ctx.resume().catch(() => {});
+  }
+
+  const now = ctx.currentTime;
+  const oscA = ctx.createOscillator();
+  const gainA = ctx.createGain();
+  oscA.type = "sine";
+  oscA.frequency.value = profile.audioFrequency;
+  gainA.gain.value = 0.0001;
+  gainA.gain.exponentialRampToValueAtTime(0.04, now + 0.03);
+  gainA.gain.exponentialRampToValueAtTime(0.0001, now + 0.22);
+  oscA.connect(gainA);
+  gainA.connect(ctx.destination);
+  oscA.start(now);
+  oscA.stop(now + 0.24);
+
+  if (summary.currentTempo === "crisis" || summary.currentTempo === "media_storm") {
+    const oscB = ctx.createOscillator();
+    const gainB = ctx.createGain();
+    oscB.type = "triangle";
+    oscB.frequency.value = profile.audioFrequency * 1.22;
+    gainB.gain.value = 0.0001;
+    gainB.gain.exponentialRampToValueAtTime(0.03, now + 0.19);
+    gainB.gain.exponentialRampToValueAtTime(0.0001, now + 0.37);
+    oscB.connect(gainB);
+    gainB.connect(ctx.destination);
+    oscB.start(now + 0.16);
+    oscB.stop(now + 0.39);
+  }
+
+  elements.audioState.textContent = DEBUG_MODE ? `${cueLabel} (audio on)` : "Audio cues on";
+}
+
+function signedDelta(value) {
+  if (value === 0) {
+    return "0";
+  }
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function extractSummaryDeltas(beforeSummary, afterSummary) {
+  return {
+    partyLoyaltyScore: afterSummary.partyLoyaltyScore - beforeSummary.partyLoyaltyScore,
+    publicApproval: afterSummary.publicApproval - beforeSummary.publicApproval,
+    constituencyApproval: afterSummary.constituencyApproval - beforeSummary.constituencyApproval,
+    pressRelationship: afterSummary.pressRelationship - beforeSummary.pressRelationship,
+    darkIndex: afterSummary.darkIndex - beforeSummary.darkIndex,
+    pendingRemediations: afterSummary.pendingRemediations - beforeSummary.pendingRemediations
+  };
+}
+
+function getDominantRecordMetric(deltas, summary) {
+  const metricTable = [
+    { key: "publicApproval", label: "Public approval", value: summary.publicApproval, delta: deltas.publicApproval },
+    { key: "pressRelationship", label: "Press relationship", value: summary.pressRelationship, delta: deltas.pressRelationship },
+    { key: "partyLoyaltyScore", label: "Party loyalty", value: summary.partyLoyaltyScore, delta: deltas.partyLoyaltyScore },
+    { key: "constituencyApproval", label: "Constituency approval", value: summary.constituencyApproval, delta: deltas.constituencyApproval },
+    { key: "darkIndex", label: "Dark index", value: summary.darkIndex, delta: deltas.darkIndex }
+  ];
+
+  metricTable.sort((left, right) => Math.abs(right.delta) - Math.abs(left.delta));
+  return metricTable[0];
+}
+
+function buildShadowLead(deltas, warnings, events) {
+  if (deltas.darkIndex > 0 || warnings.length > 0) {
+    return {
+      headline: "Lobby whispers darken around the office",
+      angle: "Sources suggest consequences are accumulating faster than statements can contain.",
+      confidence: "high"
+    };
+  }
+  if (deltas.publicApproval < 0 || deltas.pressRelationship < 0) {
+    return {
+      headline: "Narrative temperature turns against your brief",
+      angle: "Media desks and constituency chatter are converging on the same criticism pattern.",
+      confidence: Math.abs(deltas.publicApproval) + Math.abs(deltas.pressRelationship) >= 4 ? "high" : "medium"
+    };
+  }
+  if (deltas.publicApproval > 0 || deltas.partyLoyaltyScore > 0) {
+    return {
+      headline: "Backbench buzz tilts in your favour",
+      angle: "Supportive voices are amplifying the latest decision as proof of control.",
+      confidence: "medium"
+    };
+  }
+  if (events.length > 0) {
+    return {
+      headline: "Narrative churn continues without clear winner",
+      angle: "Commentariat tone remains volatile, awaiting the next packet response.",
+      confidence: "low"
+    };
+  }
+  return {
+    headline: "Quiet cycle",
+    angle: "No strong shadow lead has emerged from this step.",
+    confidence: "low"
+  };
+}
+
+function buildSupplementItems(action, deltas) {
+  const items = [];
+  if (action.kind === "challenge" && action.correct === false) {
+    items.push(`Practice brief: revisit ${action.topic} with one reinforcement problem.`);
+  }
+  if (deltas.pendingRemediations > 0) {
+    items.push(`Supplement pack: ${deltas.pendingRemediations} remediation task(s) queued.`);
+  }
+  if (action.response.events.some((event) => event.type === "TimedChallengeStarted")) {
+    items.push("Tempo drill: short timed warm-up to reduce crisis-response latency.");
+  }
+  return items.slice(0, 3);
+}
+
+function buildSmartphoneBatch(action, summary, deltas, isUrgent) {
+  const profile = getTempoProfile(summary.currentTempo);
+  const updates = [];
+
+  if (action.response.warnings.length > 0) {
+    updates.push(...action.response.warnings.map((warning) => `warning:${warning.code}`));
+  }
+
+  if (deltas.publicApproval !== 0) {
+    updates.push(`public approval ${signedDelta(deltas.publicApproval)}`);
+  }
+  if (deltas.pressRelationship !== 0) {
+    updates.push(`press relationship ${signedDelta(deltas.pressRelationship)}`);
+  }
+  if (deltas.darkIndex !== 0) {
+    updates.push(`dark index ${signedDelta(deltas.darkIndex)}`);
+  }
+  if (updates.length === 0 && action.response.events.length > 0) {
+    updates.push(`events:${action.response.events.length} routed`);
+  }
+  if (updates.length === 0) {
+    updates.push("no measurable fallout movement");
+  }
+
+  falloutBatchCounter += 1;
+  return {
+    id: `batch-${falloutBatchCounter}`,
+    label: action.label,
+    urgent: isUrgent,
+    tempo: summary.currentTempo,
+    severity: isUrgent
+      ? (summary.currentTempo === "media_storm" ? "critical" : "high")
+      : (summary.currentTempo === "parliamentary" ? "elevated" : "normal"),
+    updates: updates.slice(0, profile.updatesPerBatch)
+  };
+}
+
+function applyFalloutRouting(action) {
+  const deltas = extractSummaryDeltas(action.beforeSummary, action.response.summary);
+  const summary = action.response.summary;
+  const isUrgent = action.response.warnings.length > 0
+    || URGENT_TEMPOS.has(summary.currentTempo)
+    || deltas.darkIndex >= 2
+    || deltas.publicApproval <= -3
+    || deltas.pressRelationship <= -3;
+
+  const batch = buildSmartphoneBatch(action, summary, deltas, isUrgent);
+  smartphoneBatches = [batch, ...smartphoneBatches].slice(0, 6);
+
+  const metric = getDominantRecordMetric(deltas, summary);
+  recordLens = {
+    label: metric.label,
+    value: metric.value,
+    delta: signedDelta(metric.delta),
+    updatedAt: `${formatTempo(summary.currentTempo)} ${summary.timeHours}h`
+  };
+
+  bubbleShadowLead = buildShadowLead(deltas, action.response.warnings, action.response.events);
+  supplementItems = buildSupplementItems(action, deltas);
+
+  elements.phoneSurface.classList.toggle("urgent-physical", isUrgent);
+}
+
+function buildCollisionQueue(summary, trayState) {
+  const items = [];
+  const hasTimedPacket = currentPackets.some((packet) => Boolean(packet.challenge?.timed));
+  const latestBatch = smartphoneBatches[0];
+
+  if (URGENT_TEMPOS.has(summary.currentTempo)) {
+    items.push({
+      type: "crisis_interrupt",
+      title: "Crisis interruption",
+      detail: `${formatTempo(summary.currentTempo)} demands immediate prioritisation.`,
+      priority: COLLISION_PRIORITY.crisis_interrupt
+    });
+  }
+
+  if (hasTimedPacket) {
+    items.push({
+      type: "timed_challenge",
+      title: "Timed challenge pressure",
+      detail: "Active packet contains timed challenge constraints.",
+      priority: COLLISION_PRIORITY.timed_challenge
+    });
+  }
+
+  if (lastAction?.response?.events?.length > 0) {
+    items.push({
+      type: "packet_resolution",
+      title: "Packet resolution updates",
+      detail: `${lastAction.response.events.length} event(s) emitted from latest action.`,
+      priority: COLLISION_PRIORITY.packet_resolution
+    });
+  }
+
+  if (latestBatch) {
+    items.push({
+      type: "fallout_updates",
+      title: "Fallout surface updates",
+      detail: `${latestBatch.updates.length} routed update(s) in smartphone batch.`,
+      priority: COLLISION_PRIORITY.fallout_updates
+    });
+  }
+
+  if (bubbleShadowLead) {
+    items.push({
+      type: "flavour_updates",
+      title: "Narrative climate lead",
+      detail: bubbleShadowLead.headline,
+      priority: COLLISION_PRIORITY.flavour_updates
+    });
+  }
+
+  if (trayState === "urgent" && !items.some((item) => item.type === "timed_challenge")) {
+    items.push({
+      type: "timed_challenge",
+      title: "Urgent tray state",
+      detail: "In-Tray is signalling urgent packet handling.",
+      priority: COLLISION_PRIORITY.timed_challenge
+    });
+  }
+
+  items.sort((left, right) => left.priority - right.priority);
+  return items.slice(0, 5);
+}
+
+function renderCollisionQueue() {
+  if (collisionQueueItems.length === 0) {
+    elements.collisionQueue.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "No queue pressure." })
+    );
+    elements.collisionStamp.textContent = "priority order";
+    return;
+  }
+
+  elements.collisionQueue.replaceChildren(
+    ...collisionQueueItems.map((item) => {
+      const card = document.createElement("article");
+      card.className = `collision-item priority-${item.priority}`;
+
+      const title = document.createElement("h3");
+      title.textContent = `${item.priority}. ${item.title}`;
+
+      const detail = document.createElement("p");
+      detail.textContent = item.detail;
+
+      card.append(title, detail);
+      return card;
+    })
+  );
+  elements.collisionStamp.textContent = `top: ${collisionQueueItems[0].title}`;
+}
+
+function renderFalloutSurfaces() {
+  const profile = getTempoProfile(latestSummary?.currentTempo ?? "parliamentary");
+  const visibleBatches = smartphoneBatches.slice(0, profile.visibleBatches);
+
+  if (smartphoneBatches.length === 0) {
+    elements.phoneBatches.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "No fallout updates queued yet." })
+    );
+  } else {
+    elements.phoneBatches.replaceChildren(
+      ...visibleBatches.map((batch) => {
+        const article = document.createElement("article");
+        article.className = `phone-batch${batch.urgent ? " urgent" : ""} severity-${batch.severity}`;
+
+        const title = document.createElement("h3");
+        title.textContent = `${batch.label} | ${formatTempo(batch.tempo)}`;
+
+        const list = document.createElement("ul");
+        batch.updates.forEach((update) => {
+          const item = document.createElement("li");
+          item.textContent = update;
+          list.append(item);
+        });
+
+        article.append(title, list);
+        return article;
+      })
+    );
+  }
+
+  if (!recordLens) {
+    elements.recordStat.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        className: "meta",
+        textContent: "Record lens"
+      }),
+      Object.assign(document.createElement("p"), {
+        textContent: "No major state movement recorded yet."
+      })
+    );
+  } else {
+    const kicker = document.createElement("p");
+    kicker.className = "meta";
+    kicker.textContent = `Record lens | ${recordLens.updatedAt}`;
+
+    const value = document.createElement("p");
+    value.textContent = `${recordLens.label}: ${recordLens.value} (${recordLens.delta})`;
+    value.className = "record-value";
+
+    elements.recordStat.replaceChildren(kicker, value);
+  }
+
+  if (!bubbleShadowLead) {
+    elements.bubbleLead.replaceChildren(
+      Object.assign(document.createElement("h3"), { textContent: "Shadow lead" }),
+      Object.assign(document.createElement("p"), { textContent: "No narrative lead is active yet." })
+    );
+  } else {
+    const headline = document.createElement("h3");
+    headline.textContent = bubbleShadowLead.headline;
+
+    const angle = document.createElement("p");
+    angle.textContent = bubbleShadowLead.angle;
+
+    const confidence = document.createElement("p");
+    confidence.className = "meta";
+    confidence.textContent = `confidence: ${bubbleShadowLead.confidence}`;
+
+    elements.bubbleLead.replaceChildren(headline, angle, confidence);
+  }
+
+  if (supplementItems.length === 0) {
+    elements.supplementList.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "No supplementary items queued." })
+    );
+    elements.supplementStamp.textContent = "optional";
+  } else {
+    const list = document.createElement("ul");
+    supplementItems.forEach((itemText) => {
+      const item = document.createElement("li");
+      item.textContent = itemText;
+      list.append(item);
+    });
+    elements.supplementList.replaceChildren(list);
+    elements.supplementStamp.textContent = `${supplementItems.length} queued`;
+  }
+}
+
+function renderSummary(summary) {
+  elements.summary.replaceChildren(
+    ...summaryEntries.flatMap(([label, key]) => {
+      const dt = document.createElement("dt");
+      dt.textContent = label;
+
+      const dd = document.createElement("dd");
+      dd.textContent = String(summary[key]);
+
+      return [dt, dd];
+    })
+  );
+
+  elements.summaryStamp.textContent = `${formatTempo(summary.currentTempo)} at ${summary.timeHours}h`;
+  elements.clockReadout.textContent = `${formatTempo(summary.currentTempo)} | ${summary.timeHours}h`;
+}
+
+function renderProgression(snapshot) {
+  const promotionCard = document.createElement("article");
+  promotionCard.className = "progression-card";
+
+  const promotionHeading = document.createElement("h3");
+  promotionHeading.textContent = snapshot.promotion.nextRole
+    ? `${snapshot.promotion.currentRole} -> ${snapshot.promotion.nextRole}`
+    : `${snapshot.promotion.currentRole} is the current ceiling`;
+
+  const promotionBody = document.createElement("p");
+  promotionBody.textContent = snapshot.promotion.nextRole
+    ? snapshot.promotion.ready
+      ? "Promotion gate is currently satisfied."
+      : "Promotion gate is not yet satisfied."
+    : "No further automatic promotion gate is defined yet.";
+
+  promotionCard.append(promotionHeading, promotionBody);
+
+  if (snapshot.promotion.requirements.length > 0) {
+    const list = document.createElement("ul");
+    snapshot.promotion.requirements.forEach((requirement) => {
+      const item = document.createElement("li");
+      item.textContent = `${requirement.met ? "met" : "open"}: ${requirement.label} ${requirement.current}/${requirement.target}`;
+      list.append(item);
+    });
+    promotionCard.append(list);
+  }
+
+  const careerCard = document.createElement("article");
+  careerCard.className = "progression-card";
+
+  const careerHeading = document.createElement("h3");
+  careerHeading.textContent = snapshot.career.title;
+
+  const careerBody = document.createElement("p");
+  careerBody.textContent = snapshot.career.detail;
+
+  careerCard.append(careerHeading, careerBody);
+
+  elements.progression.replaceChildren(promotionCard, careerCard);
+  elements.promotionStamp.textContent = snapshot.career.kind;
+}
+
+function buildSection(title, body, meta) {
+  const section = document.createElement("section");
+  section.className = "packet-section";
+
+  const heading = document.createElement("h3");
+  heading.textContent = title;
+
+  const text = document.createElement("p");
+  text.textContent = body;
+
+  section.append(heading, text);
+
+  if (meta) {
+    const detail = document.createElement("p");
+    detail.textContent = meta;
+    section.append(detail);
+  }
+
+  return section;
+}
+
+function summarizeEventForPlayer(event) {
+  switch (event.type) {
+    case "ChallengeAttempted":
+      return event.payload.correct
+        ? "Answer submitted correctly."
+        : "Answer submitted incorrectly.";
+    case "ChallengeSucceeded":
+      return "Challenge passed. Confidence improves.";
+    case "ChallengeFailed":
+      return "Challenge missed. Consequences applied.";
+    case "TimeAdvanced":
+      return `Time advanced by ${event.payload.hours}h.`;
+    case "TempoChanged":
+      return `Tempo shifted to ${formatTempo(event.payload.tempo)}.`;
+    case "RoleChanged":
+      return "Role updated.";
+    case "RemediationAssigned":
+      return "Remediation task assigned.";
+    case "TimedChallengeStarted":
+      return "Timed challenge has started.";
+    case "TimedChallengeExpired":
+      return "Timed challenge expired.";
+    default:
+      return "State updated.";
+  }
+}
+
+function renderActionResult() {
+  if (!lastAction) {
+    elements.actionType.textContent = "none yet";
+    elements.actionResult.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "No challenge outcome or time advance has been submitted yet."
+      })
+    );
+    elements.eventCount.textContent = "0 emitted";
+    elements.eventLog.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "No events emitted yet."
+      })
+    );
+    return;
+  }
+
+  elements.actionType.textContent = lastAction.label;
+
+  const actionCard = document.createElement("article");
+  actionCard.className = "action-card";
+
+  const heading = document.createElement("h3");
+  heading.textContent = lastAction.heading;
+
+  const summary = document.createElement("p");
+  summary.textContent = `${formatTempo(lastAction.response.summary.currentTempo)} at ${lastAction.response.summary.timeHours}h after ${lastAction.response.events.length} event${lastAction.response.events.length === 1 ? "" : "s"}.`;
+
+  actionCard.append(heading, summary);
+
+  if (lastAction.response.warnings.length > 0) {
+    const warnings = document.createElement("p");
+    warnings.textContent = `Warnings: ${lastAction.response.warnings.map((warning) => warning.code).join(", ")}`;
+    actionCard.append(warnings);
+  }
+
+  elements.actionResult.replaceChildren(actionCard);
+
+  elements.eventCount.textContent = `${lastAction.response.events.length} emitted`;
+  if (lastAction.response.events.length === 0) {
+    elements.eventLog.replaceChildren(
+      Object.assign(document.createElement("p"), { textContent: "Action emitted no events." })
+    );
+    return;
+  }
+
+  elements.eventLog.replaceChildren(
+    ...lastAction.response.events.map((event, index) => {
+      const card = document.createElement("article");
+      card.className = "event-item";
+
+      const title = document.createElement("h3");
+      title.textContent = DEBUG_MODE ? `${index + 1}. ${event.type}` : `${index + 1}. Update`;
+
+      const body = document.createElement("p");
+      body.textContent = DEBUG_MODE ? JSON.stringify(event) : summarizeEventForPlayer(event);
+
+      card.append(title, body);
+      return card;
+    })
+  );
+}
+
+function handleChallengeOutcome(packet, correct, numericAnswer) {
+  if (!packet.challenge || !api) {
+    return;
+  }
+
+  const beforeSummary = api.getStateSummary();
+  const answerSnippet = typeof numericAnswer === "string" && numericAnswer.trim() !== ""
+    ? ` with answer ${numericAnswer.trim()}`
+    : "";
+  lastAction = {
+    kind: "challenge",
+    topic: packet.challenge.topic,
+    correct,
+    beforeSummary,
+    label: correct ? "challenge correct" : "challenge incorrect",
+    heading: `${packet.challenge.topic} marked ${correct ? "correct" : "incorrect"}${answerSnippet}`,
+    response: api.submitChallengeOutcome({
+      topic: packet.challenge.topic,
+      correct,
+      mode: packet.challenge.mode
+    })
+  };
+  applyFalloutRouting(lastAction);
+  refreshPackets();
+  setStatus(`Submitted ${packet.challenge.topic} as ${correct ? "correct" : "incorrect"}${answerSnippet}.`);
+}
+
+function handleAdvanceTime() {
+  if (!api) {
+    return;
+  }
+
+  const beforeSummary = api.getStateSummary();
+  const hours = Number.parseInt(elements.advanceHours.value, 10);
+  if (!Number.isInteger(hours) || hours <= 0) {
+    setStatus("Advance hours must be a positive integer.");
+    return;
+  }
+
+  lastAction = {
+    kind: "time",
+    beforeSummary,
+    label: "advance time",
+    heading: `Advanced simulation by ${hours}h`,
+    response: api.advanceTime(hours)
+  };
+  applyFalloutRouting(lastAction);
+  refreshPackets();
+}
+
+function renderTrayState(state, packetCount) {
+  elements.trayState.textContent = state;
+  elements.packetCount.textContent = `${packetCount} packet${packetCount === 1 ? "" : "s"} in queue`;
+  elements.openNext.disabled = packetCount === 0;
+  elements.trayAnchor.setAttribute(
+    "aria-label",
+    `In-Tray ${state}. ${packetCount} packet${packetCount === 1 ? "" : "s"} available.`
+  );
+}
+
+function renderPacket(packet, index) {
+  const article = document.createElement("article");
+  article.className = "packet";
+  const isCrisisVariant = Boolean(packet.challenge?.timed) || Boolean(latestSummary && URGENT_TEMPOS.has(latestSummary.currentTempo));
+  if (isCrisisVariant) {
+    article.classList.add("packet-crisis");
+  }
+
+  const kicker = document.createElement("p");
+  kicker.className = "doc-kicker";
+  kicker.textContent = isCrisisVariant ? "Crisis packet" : "Event/Decision brief";
+  article.append(kicker);
+
+  const header = document.createElement("div");
+  header.className = "packet-header";
+
+  const title = document.createElement("h3");
+  title.textContent = packet.eventCard?.title ?? `Packet ${index + 1}`;
+
+  const badge = document.createElement("span");
+  badge.className = "badge";
+  badge.textContent = packet.band;
+
+  header.append(title, badge);
+  article.append(header);
+
+  article.append(buildSection("Briefing", packet.eventCard?.description ?? "No event card supplied for this packet."));
+
+  if (packet.challenge) {
+    const timer = packet.challenge.timed && packet.challenge.timerSeconds
+      ? `Timed: ${packet.challenge.timerSeconds}s`
+      : `Mode: ${packet.challenge.mode}`;
+    article.append(buildSection("Decision task", packet.challenge.prompt, `${packet.challenge.topic} | ${timer}`));
+
+    const form = document.createElement("form");
+    form.className = "challenge-form";
+    form.setAttribute("aria-label", `Challenge response for ${packet.challenge.topic}`);
+
+    const answerLabel = document.createElement("label");
+    answerLabel.textContent = "Numeric answer";
+
+    const answerInput = document.createElement("input");
+    answerInput.type = "number";
+    answerInput.step = "any";
+    answerInput.inputMode = "decimal";
+    answerInput.required = true;
+    answerInput.placeholder = "Enter value";
+    answerInput.setAttribute("aria-label", "Numeric answer input");
+    answerLabel.append(answerInput);
+
+    const helper = document.createElement("p");
+    helper.className = "challenge-help";
+    helper.textContent = DEBUG_MODE
+      ? "Standard numeric input is required. Use Submit answer for auto-marking, or debug controls to force outcomes."
+      : "Enter a numeric answer, then submit for marking.";
+
+    const actions = document.createElement("div");
+    actions.className = "packet-actions";
+
+    const submitAnswer = document.createElement("button");
+    submitAnswer.type = "submit";
+    submitAnswer.textContent = "Submit answer";
+
+    const fallbackCorrect = document.createElement("button");
+    fallbackCorrect.type = "button";
+    fallbackCorrect.textContent = "Fallback: mark correct";
+    fallbackCorrect.classList.add("debug-only");
+    fallbackCorrect.toggleAttribute("hidden", !DEBUG_MODE);
+    fallbackCorrect.addEventListener("click", () => {
+      if (!answerInput.reportValidity()) {
+        return;
+      }
+      handleChallengeOutcome(packet, true, answerInput.value);
+    });
+
+    const fallbackIncorrect = document.createElement("button");
+    fallbackIncorrect.type = "button";
+    fallbackIncorrect.textContent = "Fallback: mark incorrect";
+    fallbackIncorrect.classList.add("debug-only");
+    fallbackIncorrect.toggleAttribute("hidden", !DEBUG_MODE);
+    fallbackIncorrect.addEventListener("click", () => {
+      if (!answerInput.reportValidity()) {
+        return;
+      }
+      handleChallengeOutcome(packet, false, answerInput.value);
+    });
+
+    actions.append(submitAnswer, fallbackCorrect, fallbackIncorrect);
+    form.append(answerLabel, helper, actions);
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      if (!answerInput.reportValidity()) {
+        return;
+      }
+      const submitter = event.submitter || document.activeElement;
+      let correct;
+      if (DEBUG_MODE && submitter?.dataset.outcome) {
+        correct = submitter.dataset.outcome !== "incorrect";
+      } else {
+        correct = resolveChallengeCorrectness(packet, answerInput.value);
+      }
+      if (correct === undefined) {
+        setStatus("Could not grade this answer automatically. Use debug mode to force outcome if needed.");
+        return;
+      }
+      handleChallengeOutcome(packet, correct, answerInput.value);
+    });
+    article.append(form);
+  }
+
+  if (packet.scene) {
+    const sceneSection = document.createElement("section");
+    sceneSection.className = "scene-attachment";
+
+    const sceneHeading = document.createElement("h4");
+    sceneHeading.textContent = "Attached scene memo";
+
+    const sceneBody = document.createElement("p");
+    sceneBody.textContent = packet.scene.text;
+
+    const sceneMeta = document.createElement("p");
+    sceneMeta.className = "meta";
+    sceneMeta.textContent = `NPC: ${packet.scene.npcId}`;
+
+    sceneSection.append(sceneHeading, sceneBody, sceneMeta);
+    article.append(sceneSection);
+  }
+
+  return article;
+}
+
+function renderPacketFocus() {
+  if (activePacketIndex < 0 || !currentPackets[activePacketIndex]) {
+    elements.packetFullscreenToggle.disabled = true;
+    elements.packetFocus.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "No active packet selected. Open the tray to pull the next packet into focus."
+      })
+    );
+    elements.packetFocus.removeAttribute("aria-label");
+    return;
+  }
+
+  elements.packetFullscreenToggle.disabled = false;
+  const packet = currentPackets[activePacketIndex];
+  elements.packetFocus.setAttribute(
+    "aria-label",
+    `Active packet ${activePacketIndex + 1}: ${packet.eventCard?.title ?? "Untitled packet"}`
+  );
+  elements.packetFocus.replaceChildren(renderPacket(packet, activePacketIndex));
+}
+
+function setActivePacket(index) {
+  if (index < 0 || index >= currentPackets.length) {
+    activePacketIndex = -1;
+    renderPacketFocus();
+    return;
+  }
+
+  activePacketIndex = index;
+  renderPacketFocus();
+  renderPacketQueue();
+  elements.packetFocus.focus({ preventScroll: true });
+}
+
+function renderPacketQueue() {
+  if (currentPackets.length === 0) {
+    elements.packets.replaceChildren(
+      Object.assign(document.createElement("p"), {
+        textContent: "Tray is clear. Advance time or refresh to continue."
+      })
+    );
+    return;
+  }
+
+  elements.packets.replaceChildren(
+    ...currentPackets.map((packet, index) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `queue-item${index === activePacketIndex ? " active" : ""}`;
+      button.textContent = packet.eventCard?.title ?? `Packet ${index + 1}`;
+      button.addEventListener("click", () => {
+        setActivePacket(index);
+      });
+      return button;
+    })
+  );
+}
+
+function renderNextAction(trayState) {
+  if (!elements.nextAction) {
+    return;
+  }
+
+  const hasActivePacket = activePacketIndex >= 0 && Boolean(currentPackets[activePacketIndex]);
+  const activePacket = hasActivePacket ? currentPackets[activePacketIndex] : undefined;
+  const isUrgentInterruptVisible = !elements.interrupt.classList.contains("hidden");
+
+  if (isUrgentInterruptVisible) {
+    elements.nextAction.textContent = "Urgent item active. Return to active task and resolve it first.";
+    return;
+  }
+  if (currentPackets.length === 0) {
+    elements.nextAction.textContent = "No brief is waiting. Advance time to generate the next work cycle.";
+    return;
+  }
+  if (!hasActivePacket) {
+    elements.nextAction.textContent = "Open the next brief from In-Tray.";
+    return;
+  }
+  if (activePacket?.challenge) {
+    elements.nextAction.textContent = "Read the brief, enter your numeric answer, then submit.";
+    return;
+  }
+  elements.nextAction.textContent = "Review this brief, then open the next one from In-Tray.";
+}
+
+function openNextPacketFromTray() {
+  if (currentPackets.length === 0) {
+    setStatus("In-Tray is idle. No packet available to open.");
+    return;
+  }
+
+  const nextIndex = activePacketIndex < 0 ? 0 : Math.min(activePacketIndex + 1, currentPackets.length - 1);
+  setActivePacket(nextIndex);
+  if (isNarrowViewport()) {
+    setPacketFullscreen(true);
+  }
+  setStatus(`Opened packet ${nextIndex + 1} from In-Tray.`);
+}
+
+function findPrimaryTaskTarget() {
+  if (activePacketIndex >= 0) {
+    return elements.packetFocus.querySelector("input, button") || elements.packetFocus;
+  }
+  return elements.openNext;
+}
+
+function maybeRenderInterrupt(summary, trayState) {
+  const top = collisionQueueItems[0];
+  const urgentFallout = smartphoneBatches[0]?.urgent === true;
+  const isUrgent = Boolean(top && top.priority <= 2) || trayState === "urgent" || urgentFallout;
+  const interruptKey = `${summary.timeHours}:${summary.currentTempo}:${trayState}:${top?.type ?? "none"}:${urgentFallout ? "fallout" : "normal"}`;
+  const shouldShow = isUrgent && dismissedInterruptKey !== interruptKey;
+
+  if (!shouldShow) {
+    elements.interrupt.classList.add("hidden");
+    return;
+  }
+
+  elements.interrupt.classList.remove("hidden");
+  if (top?.type === "crisis_interrupt") {
+    elements.interruptTitle.textContent = "Crisis interruption";
+    elements.interruptBody.textContent = top.detail;
+  } else if (top?.type === "timed_challenge") {
+    elements.interruptTitle.textContent = "Timed challenge pressure";
+    elements.interruptBody.textContent = top.detail;
+  } else if (urgentFallout) {
+    elements.interruptTitle.textContent = "Urgent fallout alert";
+    elements.interruptBody.textContent = "High-priority consequences were routed to Smartphone. Use return to continue the active packet path.";
+  } else {
+    elements.interruptTitle.textContent = `${formatTempo(summary.currentTempo)} pressure state`;
+    elements.interruptBody.textContent = "Urgent state is active. Use In-Tray or active packet to clear priority work.";
+  }
+  elements.interruptDismiss.onclick = () => {
+    dismissedInterruptKey = interruptKey;
+    elements.interrupt.classList.add("hidden");
+    setStatus("Urgent interruption acknowledged. Priority controls remain available.");
+  };
+  elements.interruptReturn.onclick = () => {
+    const target = findPrimaryTaskTarget();
+    target.focus();
+    setStatus("Returned to highest-priority task path.");
+  };
+}
+
+function refreshPackets() {
+  if (!api) {
+    return;
+  }
+
+  const summary = api.getStateSummary();
+  const progression = api.getProgressionStatus();
+  currentPackets = api.getCurrentPacketBatch();
+  latestSummary = summary;
+
+  if (activePacketIndex >= currentPackets.length) {
+    activePacketIndex = currentPackets.length > 0 ? 0 : -1;
+  }
+  if (currentPackets.length === 0) {
+    setPacketFullscreen(false);
+  }
+  if (!isNarrowViewport() && packetFullscreen) {
+    setPacketFullscreen(false);
+  }
+
+  const trayState = computeTrayState(summary, currentPackets);
+  const pressureProfile = getTempoProfile(summary.currentTempo);
+  setTempoVisualState(summary.currentTempo);
+  collisionQueueItems = buildCollisionQueue(summary, trayState);
+
+  renderSummary(summary);
+  renderProgression(progression);
+  renderTrayState(trayState, currentPackets.length);
+  renderPacketQueue();
+  renderPacketFocus();
+  elements.packetFocus.classList.remove("pressure-high", "pressure-medium");
+  if (pressureProfile.pressureClass === "crisis" || pressureProfile.pressureClass === "media_storm") {
+    elements.packetFocus.classList.add("pressure-high");
+  } else if (pressureProfile.pressureClass === "parliamentary") {
+    elements.packetFocus.classList.add("pressure-medium");
+  }
+  renderActionResult();
+  renderFalloutSurfaces();
+  renderCollisionQueue();
+  maybeRenderInterrupt(summary, trayState);
+  renderNextAction(trayState);
+
+  const topCollision = collisionQueueItems[0]?.type ?? "none";
+  const cueKey = `${summary.currentTempo}:${topCollision}`;
+  if (summary.currentTempo !== lastTempoForCue || (collisionQueueItems[0] && cueKey !== lastCollisionCueKey)) {
+    playPressureCue(summary, topCollision);
+    lastTempoForCue = summary.currentTempo;
+    lastCollisionCueKey = cueKey;
+  }
+
+  elements.focusOrderStamp.textContent = SURFACE_FOCUS_ORDER.join(" -> ");
+  setStatus(DEBUG_MODE ? `Tier 1 shell rendered. Tray state: ${trayState}.` : "Desk updated.");
+}
+
+function focusSurface(surface) {
+  surface.scrollIntoView({ behavior: reducedMotionEnabled ? "auto" : "smooth", block: "center" });
+  surface.focus({ preventScroll: true });
+}
+
+async function loadBundle() {
+  const response = await fetch("/content/vertical-slice.json");
+  if (!response.ok) {
+    throw new Error(`Failed to load content bundle (${response.status})`);
+  }
+  const bundle = await response.json();
+  validateContentBundle(bundle);
+  const answerEntries = Array.isArray(bundle.challenges)
+    ? bundle.challenges
+      .filter((challenge) => challenge && typeof challenge.id === "string" && typeof challenge.answer === "number")
+      .map((challenge) => [challenge.id, challenge.answer])
+    : [];
+  challengeAnswerById = new Map(answerEntries);
+  return bundle;
+}
+
+async function boot() {
+  setStatus("Loading vertical slice content…");
+  const bundle = await loadBundle();
+  lastAction = null;
+  dismissedInterruptKey = null;
+  falloutBatchCounter = 0;
+  smartphoneBatches = [];
+  recordLens = null;
+  bubbleShadowLead = null;
+  supplementItems = [];
+  collisionQueueItems = [];
+  lastTempoForCue = null;
+  lastCollisionCueKey = "";
+  currentPackets = [];
+  activePacketIndex = -1;
+  latestSummary = null;
+  setPacketFullscreen(false);
+  setTempoVisualState("parliamentary");
+  elements.phoneSurface.classList.remove("urgent-physical");
+  api = await PrototypeApi.create({
+    schoolYear: elements.schoolYear.value,
+    contentBundle: bundle
+  });
+  refreshPackets();
+}
+
+function wireEvents() {
+  elements.trayAnchor.addEventListener("click", () => {
+    openNextPacketFromTray();
+  });
+  elements.openNext.addEventListener("click", () => {
+    openNextPacketFromTray();
+  });
+  elements.packetFullscreenToggle.addEventListener("click", () => {
+    setPacketFullscreen(true);
+    setStatus("Packet switched to fullscreen view.");
+  });
+  elements.packetFullscreenClose.addEventListener("click", () => {
+    setPacketFullscreen(false);
+    setStatus("Returned from fullscreen packet view.");
+  });
+  elements.audioToggle.addEventListener("click", () => {
+    audioEnabled = !audioEnabled;
+    elements.audioToggle.textContent = audioEnabled ? "Disable audio cues" : "Enable audio cues";
+    elements.audioState.textContent = audioEnabled ? "audio cues on" : "audio cues off";
+    if (audioEnabled) {
+      const ctx = ensureAudioContext();
+      if (!ctx) {
+        audioEnabled = false;
+        elements.audioToggle.textContent = "Enable audio cues";
+        elements.audioState.textContent = "audio unavailable; visual cues only";
+      } else {
+        playPressureCue(latestSummary ?? { currentTempo: "parliamentary" }, "manual_toggle");
+      }
+    }
+  });
+  if (elements.cleanReadToggle) {
+    elements.cleanReadToggle.addEventListener("change", () => {
+      cleanReadEnabled = elements.cleanReadToggle.checked;
+      applyAccessibilityModes();
+      persistAccessibilityModes();
+      setStatus(cleanReadEnabled ? "Clean-read mode enabled." : "Clean-read mode disabled.");
+    });
+  }
+  if (elements.reducedMotionToggle) {
+    elements.reducedMotionToggle.addEventListener("change", () => {
+      reducedMotionEnabled = elements.reducedMotionToggle.checked;
+      applyAccessibilityModes();
+      persistAccessibilityModes();
+      setStatus(reducedMotionEnabled ? "Reduced-motion mode enabled." : "Reduced-motion mode disabled.");
+    });
+  }
+
+  elements.refresh.addEventListener("click", () => {
+    refreshPackets();
+  });
+
+  elements.advance.addEventListener("click", () => {
+    handleAdvanceTime();
+  });
+
+  elements.restart.addEventListener("click", async () => {
+    try {
+      await boot();
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Failed to restart prototype shell.");
+    }
+  });
+
+  elements.phoneAnchor.addEventListener("click", () => {
+    focusSurface(elements.phoneSurface);
+    setStatus("Smartphone anchor opened immediate fallout surface.");
+  });
+  elements.recordAnchor.addEventListener("click", () => {
+    focusSurface(elements.recordSurface);
+    setStatus("The Record anchor opened official summary surface.");
+  });
+  elements.bubbleAnchor.addEventListener("click", () => {
+    focusSurface(elements.bubbleSurface);
+    setStatus("The Bubble anchor opened narrative event wire.");
+  });
+  elements.supplementAnchor.addEventListener("click", () => {
+    focusSurface(elements.supplementSurface);
+    setStatus("The Supplement anchor opened optional enrichment surface.");
+  });
+  elements.lampAnchor.addEventListener("click", () => {
+    setStatus("Lamp fallback activated. Save/Quit action remains available through explicit controls.");
+  });
+
+  window.addEventListener("keydown", (event) => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+      return;
+    }
+
+    if (event.key === "Escape" && packetFullscreen) {
+      setPacketFullscreen(false);
+      setStatus("Exited fullscreen packet view with Escape.");
+      return;
+    }
+
+    const key = event.key.toLowerCase();
+    if (key === "t") {
+      elements.trayAnchor.focus();
+      return;
+    }
+    if (key === "p") {
+      focusSurface(elements.packetFocus);
+      return;
+    }
+    if (key === "s") {
+      focusSurface(elements.phoneSurface);
+      return;
+    }
+    if (key === "r") {
+      focusSurface(elements.recordSurface);
+      return;
+    }
+    if (key === "b") {
+      focusSurface(elements.bubbleSurface);
+      return;
+    }
+    if (key === "u") {
+      focusSurface(elements.supplementSurface);
+      return;
+    }
+    if (key === "d") {
+      focusSurface(elements.diarySurface);
+    }
+  });
+  window.addEventListener("resize", () => {
+    if (!isNarrowViewport() && packetFullscreen) {
+      setPacketFullscreen(false);
+    }
+  });
+}
+
+applyDebugMode();
+loadAccessibilityModes();
+wireEvents();
+
+boot().catch((error) => {
+  setStatus(error instanceof Error ? error.message : "Prototype shell failed to boot.");
+});

--- a/prototype/app.js
+++ b/prototype/app.js
@@ -726,9 +726,7 @@ function renderActionResult() {
     );
     elements.eventCount.textContent = "0 emitted";
     elements.eventLog.replaceChildren(
-      Object.assign(document.createElement("p"), {
-        textContent: "No events emitted yet."
-      })
+      Object.assign(document.createElement("p"), { textContent: "No outcome updates yet." })
     );
     return;
   }
@@ -870,7 +868,12 @@ function renderPacket(packet, index) {
   header.append(title, badge);
   article.append(header);
 
-  article.append(buildSection("Briefing", packet.eventCard?.description ?? "No event card supplied for this packet."));
+  article.append(
+    buildSection(
+      "Briefing",
+      packet.eventCard?.description ?? (DEBUG_MODE ? "No event card supplied for this packet." : "Briefing content unavailable.")
+    )
+  );
 
   if (packet.challenge) {
     const timer = packet.challenge.timed && packet.challenge.timerSeconds
@@ -969,11 +972,13 @@ function renderPacket(packet, index) {
     const sceneBody = document.createElement("p");
     sceneBody.textContent = packet.scene.text;
 
-    const sceneMeta = document.createElement("p");
-    sceneMeta.className = "meta";
-    sceneMeta.textContent = `NPC: ${packet.scene.npcId}`;
-
-    sceneSection.append(sceneHeading, sceneBody, sceneMeta);
+    sceneSection.append(sceneHeading, sceneBody);
+    if (DEBUG_MODE) {
+      const sceneMeta = document.createElement("p");
+      sceneMeta.className = "meta";
+      sceneMeta.textContent = `NPC: ${packet.scene.npcId}`;
+      sceneSection.append(sceneMeta);
+    }
     article.append(sceneSection);
   }
 
@@ -1104,8 +1109,10 @@ function maybeRenderInterrupt(summary, trayState) {
     elements.interruptTitle.textContent = "Crisis interruption";
     elements.interruptBody.textContent = top.detail;
   } else if (top?.type === "timed_challenge") {
-    elements.interruptTitle.textContent = "Timed challenge pressure";
-    elements.interruptBody.textContent = top.detail;
+    elements.interruptTitle.textContent = "Time pressure";
+    elements.interruptBody.textContent = DEBUG_MODE
+      ? top.detail
+      : "A timed task is active. Return to your current brief and respond quickly.";
   } else if (urgentFallout) {
     elements.interruptTitle.textContent = "Urgent fallout alert";
     elements.interruptBody.textContent = "High-priority consequences need attention. Use return to continue your current brief.";

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -65,7 +65,7 @@
           <header class="zone-header">
             <div>
               <h2>Current Brief</h2>
-              <p id="packet-count" class="meta">0 packets</p>
+              <p id="packet-count" class="meta">0 briefs waiting</p>
             </div>
             <div class="zone-actions">
               <button id="packet-fullscreen-toggle" type="button">Fullscreen packet</button>
@@ -162,7 +162,7 @@
             <span id="action-type" class="meta debug-only">none yet</span>
           </div>
           <div id="phone-batches" class="phone-batches">
-            <p>No fallout updates queued yet.</p>
+            <p>No consequences recorded yet.</p>
           </div>
           <div id="action-result" class="action-result">
             <p>No challenge outcome or time advance has been submitted yet.</p>
@@ -179,7 +179,7 @@
             <p>No narrative lead is active yet.</p>
           </div>
           <div id="event-log" class="event-log">
-            <p>No events emitted yet.</p>
+            <p>No outcome updates yet.</p>
           </div>
         </article>
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>To The Power Prototype - Tier 1 Shell</title>
+    <link rel="stylesheet" href="/prototype/styles.css" />
+  </head>
+  <body>
+    <nav class="skip-links" aria-label="Skip links">
+      <a href="#tray-anchor">Skip to In-Tray</a>
+      <a href="#packet-focus">Skip to active packet</a>
+      <a href="#phone-surface">Skip to smartphone</a>
+      <a class="debug-only" href="#collision-surface">Skip to collision queue</a>
+    </nav>
+    <main class="shell">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">Playtest Build</p>
+          <h1>Tier 1 Desk</h1>
+        </div>
+        <p id="status" class="status" role="status">Booting desk shell…</p>
+      </header>
+      <section id="next-action" class="next-action" aria-live="polite">
+        Open the next brief from In-Tray to begin.
+      </section>
+
+      <section id="interrupt" class="interrupt hidden" aria-live="assertive" aria-label="Urgent interruption">
+        <div>
+          <p class="interrupt-kicker">Urgent interruption</p>
+          <h2 id="interrupt-title">Crisis desk takeover</h2>
+          <p id="interrupt-body">Immediate action is required.</p>
+        </div>
+        <div class="interrupt-actions">
+          <button id="interrupt-return" type="button">Return to active task</button>
+          <button id="interrupt-dismiss" type="button">Acknowledge</button>
+        </div>
+      </section>
+
+      <section class="desk" aria-label="Tier 1 desk">
+        <aside class="anchor-column" aria-label="Desk anchors">
+          <button id="tray-anchor" class="desk-object tray" type="button">
+            <span class="object-title">In-Tray</span>
+            <span id="tray-state" class="object-meta">idle</span>
+          </button>
+          <button id="phone-anchor" class="desk-object" type="button">
+            <span class="object-title">Smartphone</span>
+            <span class="object-meta">fallout</span>
+          </button>
+          <button id="record-anchor" class="desk-object" type="button">
+            <span class="object-title">The Record</span>
+            <span class="object-meta">official</span>
+          </button>
+          <button id="bubble-anchor" class="desk-object" type="button">
+            <span class="object-title">The Bubble</span>
+            <span class="object-meta">rumour</span>
+          </button>
+          <button id="supplement-anchor" class="desk-object" type="button">
+            <span class="object-title">The Supplement</span>
+            <span class="object-meta">optional</span>
+          </button>
+        </aside>
+
+        <section class="packet-zone" aria-label="Active packet zone">
+          <header class="zone-header">
+            <div>
+              <h2>Current Brief</h2>
+              <p id="packet-count" class="meta">0 packets</p>
+            </div>
+            <div class="zone-actions">
+              <button id="packet-fullscreen-toggle" type="button">Fullscreen packet</button>
+              <button id="packet-fullscreen-close" class="hidden" type="button">Close fullscreen</button>
+              <button id="open-next" type="button">Open brief from In-Tray</button>
+            </div>
+          </header>
+          <div id="packet-focus" class="packet-focus" tabindex="-1" aria-live="polite"></div>
+          <div id="packets" class="packet-queue" aria-label="Packet queue"></div>
+        </section>
+
+        <aside class="surface-column" aria-label="Support surfaces">
+          <section id="diary-surface" class="surface-card" aria-label="Diary and controls" tabindex="-1">
+            <header class="surface-header">
+              <h2>Desk Controls</h2>
+              <span id="focus-order-stamp" class="meta debug-only">focus order set</span>
+            </header>
+            <div class="controls">
+              <label class="debug-only">
+                School year
+                <select id="school-year">
+                  <option value="Y9">Year 9</option>
+                  <option value="Y10">Year 10</option>
+                  <option value="Y11">Year 11</option>
+                </select>
+              </label>
+              <label>
+                Advance hours
+                <input id="advance-hours" type="number" min="1" step="1" value="6" />
+              </label>
+              <div class="button-row">
+                <button id="advance" type="button">Advance time</button>
+                <button id="refresh" class="debug-only" type="button">Refresh batch</button>
+                <button id="restart" class="debug-only" type="button">Restart shell</button>
+              </div>
+              <fieldset class="accessibility-controls">
+                <legend>Accessibility modes</legend>
+                <label class="toggle-row">
+                  <input id="clean-read-toggle" type="checkbox" />
+                  Clean-read and contrast simplification
+                </label>
+                <label class="toggle-row">
+                  <input id="reduced-motion-toggle" type="checkbox" />
+                  Reduced motion override
+                </label>
+              </fieldset>
+              <p class="meta keyboard-hint">Shortcuts: `t` tray, `p` packet, `s` phone, `r` record, `b` bubble, `u` supplement, `d` diary.</p>
+            </div>
+          </section>
+
+          <section id="clock-surface" class="surface-card" aria-label="Clock" tabindex="-1">
+            <header class="surface-header">
+              <h2>Clock</h2>
+              <span id="tempo-state" class="meta">tempo</span>
+            </header>
+            <p id="clock-readout" class="clock-readout">tempo unknown</p>
+            <p id="audio-state" class="meta">audio cues off</p>
+            <button id="audio-toggle" type="button">Enable audio cues</button>
+          </section>
+
+          <section class="surface-card lamp-card debug-only" aria-label="Lamp and save path">
+            <header class="surface-header">
+              <h2>Lamp</h2>
+            </header>
+            <button id="lamp-anchor" type="button">Save/Quit fallback (status only)</button>
+          </section>
+        </aside>
+      </section>
+
+      <section class="detail-grid" aria-label="Consequences and diagnostics">
+        <article id="record-surface" class="panel" tabindex="-1">
+          <div class="panel-header">
+            <h2>Public Briefing</h2>
+            <span id="summary-stamp" class="meta debug-only"></span>
+          </div>
+          <div id="record-stat" class="record-stat">
+            <p class="meta">Record lens</p>
+            <p>No major state movement recorded yet.</p>
+          </div>
+          <dl id="summary" class="summary debug-only"></dl>
+        </article>
+
+        <article class="panel debug-only">
+          <div class="panel-header">
+            <h2>Progression</h2>
+            <span id="promotion-stamp" class="meta"></span>
+          </div>
+          <div id="progression" class="progression"></div>
+        </article>
+
+        <article id="phone-surface" class="panel" tabindex="-1">
+          <div class="panel-header">
+            <h2>Latest Consequences</h2>
+            <span id="action-type" class="meta debug-only">none yet</span>
+          </div>
+          <div id="phone-batches" class="phone-batches">
+            <p>No fallout updates queued yet.</p>
+          </div>
+          <div id="action-result" class="action-result">
+            <p>No challenge outcome or time advance has been submitted yet.</p>
+          </div>
+        </article>
+
+        <article id="bubble-surface" class="panel panel-wide" tabindex="-1">
+          <div class="panel-header">
+            <h2>Outcome Log</h2>
+            <span id="event-count" class="meta debug-only">0 emitted</span>
+          </div>
+          <div id="bubble-lead" class="bubble-lead">
+            <h3>Shadow lead</h3>
+            <p>No narrative lead is active yet.</p>
+          </div>
+          <div id="event-log" class="event-log">
+            <p>No events emitted yet.</p>
+          </div>
+        </article>
+
+        <article id="collision-surface" class="panel panel-wide debug-only" tabindex="-1">
+          <div class="panel-header">
+            <h2>Collision Queue</h2>
+            <span id="collision-stamp" class="meta">priority order</span>
+          </div>
+          <div id="collision-queue" class="collision-queue">
+            <p>No queue pressure.</p>
+          </div>
+        </article>
+
+        <article id="supplement-surface" class="panel panel-wide" tabindex="-1">
+          <div class="panel-header">
+            <h2>Background Briefings</h2>
+            <span id="supplement-stamp" class="meta">optional</span>
+          </div>
+          <div id="supplement-list" class="supplement-list">
+            <p>No supplementary items queued.</p>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script type="module" src="/prototype/app.js"></script>
+  </body>
+</html>

--- a/prototype/styles.css
+++ b/prototype/styles.css
@@ -1,0 +1,828 @@
+:root {
+  color-scheme: light;
+  --ink: #191c22;
+  --muted: #4f5767;
+  --paper: #f7f1e5;
+  --card: #fbf7ef;
+  --desk: #c9a57b;
+  --desk-deep: #9f7f5c;
+  --wood-grain-a: rgba(106, 70, 40, 0.16);
+  --wood-grain-b: rgba(255, 239, 214, 0.1);
+  --accent: #7b2e21;
+  --accent-soft: #edd1bc;
+  --line: rgba(28, 31, 39, 0.18);
+  --urgent: #a32626;
+  --ok: #2f6242;
+  --shadow: 0 22px 44px rgba(32, 24, 18, 0.2);
+  --surface-shine: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  --focus-ring: 0 0 0 3px rgba(123, 46, 33, 0.3);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(143, 60, 45, 0.16), transparent 34%),
+    linear-gradient(180deg, #e8d8bf 0%, #ddc9aa 52%, #d3bc98 100%);
+  color: var(--ink);
+  font-family: "Baskerville", Georgia, "Times New Roman", serif;
+}
+
+body.clean-read {
+  --paper: #fcfbf8;
+  --card: #ffffff;
+  --line: rgba(16, 20, 28, 0.28);
+  --muted: #2f3848;
+  --accent: #5f160c;
+  --shadow: 0 8px 20px rgba(22, 20, 17, 0.12);
+  background: #f5f5f2;
+}
+
+body.clean-read .desk {
+  background: linear-gradient(180deg, #ece6dc 0%, #dfd6c8 100%);
+}
+
+body.clean-read .packet-zone,
+body.clean-read .panel,
+body.clean-read .surface-card,
+body.clean-read .desk-object {
+  background: #ffffff;
+}
+
+body.clean-read .panel.urgent-physical,
+body.clean-read .phone-batch.urgent,
+body.clean-read .collision-item.priority-1,
+body.clean-read .packet-focus.pressure-high {
+  border-color: #8f1010;
+  background: #fff6f6;
+}
+
+body.reduced-motion *,
+body.reduced-motion *::before,
+body.reduced-motion *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+.skip-links {
+  position: absolute;
+  left: 0.75rem;
+  top: 0.5rem;
+  display: flex;
+  gap: 0.45rem;
+  z-index: 60;
+}
+
+.skip-links a {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  background: #fff;
+  color: var(--ink);
+  padding: 0.4rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  font-size: 0.82rem;
+  text-decoration: none;
+}
+
+.skip-links a:focus {
+  position: static;
+  left: auto;
+}
+
+body.tempo-recess {
+  background:
+    radial-gradient(circle at 15% 0%, rgba(79, 129, 96, 0.14), transparent 34%),
+    linear-gradient(180deg, #e9e2d1 0%, #e2d8c4 52%, #dacdb7 100%);
+}
+
+body.tempo-parliamentary {
+  background:
+    radial-gradient(circle at 10% 0%, rgba(143, 60, 45, 0.18), transparent 32%),
+    linear-gradient(180deg, #efe3d1 0%, #e7dbc8 50%, #dfd1bc 100%);
+}
+
+body.tempo-crisis {
+  background:
+    radial-gradient(circle at 10% 0%, rgba(163, 38, 38, 0.26), transparent 34%),
+    linear-gradient(180deg, #ead7d0 0%, #e4cfc6 50%, #dac2b9 100%);
+}
+
+body.tempo-media_storm {
+  background:
+    radial-gradient(circle at 85% 10%, rgba(118, 76, 24, 0.24), transparent 36%),
+    radial-gradient(circle at 15% 0%, rgba(163, 38, 38, 0.2), transparent 32%),
+    linear-gradient(180deg, #e8d8cf 0%, #dccbbf 52%, #d2c0b3 100%);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.shell {
+  width: min(1240px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.25rem 0 2rem;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.next-action {
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--line) 66%);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fffaf3 0%, #f6ead8 100%);
+  padding: 0.65rem 0.8rem;
+  margin-bottom: 0.9rem;
+  font-family: "Trebuchet MS", sans-serif;
+  font-size: 0.92rem;
+  color: color-mix(in srgb, var(--ink) 86%, var(--accent) 14%);
+}
+
+.eyebrow,
+.status,
+.meta,
+.object-meta {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.eyebrow {
+  margin: 0 0 0.4rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2.2rem, 4.8vw, 3.2rem);
+  line-height: 1;
+}
+
+.status {
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-align: right;
+  max-width: 26rem;
+}
+
+.interrupt {
+  border: 1px solid rgba(163, 38, 38, 0.45);
+  background: #fff3f1;
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  box-shadow: 0 10px 18px rgba(163, 38, 38, 0.16);
+  margin-bottom: 1rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.interrupt-kicker {
+  color: var(--urgent);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.interrupt h2 {
+  font-size: 1.2rem;
+  margin-top: 0.2rem;
+}
+
+.interrupt p + p {
+  margin-top: 0.3rem;
+}
+
+.interrupt-actions {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.desk {
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background:
+    repeating-linear-gradient(
+      12deg,
+      var(--wood-grain-a) 0px,
+      var(--wood-grain-a) 2px,
+      transparent 2px,
+      transparent 7px
+    ),
+    linear-gradient(150deg, var(--wood-grain-b), transparent 36%),
+    linear-gradient(180deg, var(--desk) 0%, var(--desk-deep) 100%);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) 320px;
+  gap: 0.9rem;
+}
+
+.anchor-column,
+.surface-column {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.desk-object,
+.surface-card,
+.packet-zone,
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.66), rgba(255, 255, 255, 0.15)),
+    color-mix(in srgb, var(--card) 96%, white 4%);
+  box-shadow: var(--surface-shine);
+}
+
+.desk-object {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.7rem 0.8rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.desk-object.tray {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line) 60%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-soft) 65%, white 35%);
+}
+
+.object-title {
+  font-size: 1.02rem;
+}
+
+.object-meta,
+.meta {
+  font-size: 0.66rem;
+  color: var(--muted);
+}
+
+.packet-zone,
+.surface-card,
+.panel {
+  padding: 0.85rem;
+}
+
+.packet-zone {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.zone-header,
+.surface-header,
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  align-items: baseline;
+}
+
+.zone-actions {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: end;
+}
+
+.zone-header button,
+.button-row button,
+.interrupt-actions button,
+.lamp-card button {
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, #fff 0%, #f1e8d7 100%);
+  border-radius: 999px;
+  padding: 0.56rem 0.82rem;
+}
+
+button:hover,
+button:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--line) 52%);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+a:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.packet-focus {
+  min-height: 300px;
+  border: 1px dashed color-mix(in srgb, var(--line) 72%, var(--muted) 28%);
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 70% 0%, rgba(255, 255, 255, 0.8), transparent 30%),
+    var(--paper);
+  padding: 0.8rem;
+}
+
+.packet {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.packet.packet-crisis {
+  border: 1px solid rgba(163, 38, 38, 0.45);
+  border-radius: 10px;
+  padding: 0.55rem;
+  background: #fff4f2;
+}
+
+.doc-kicker {
+  font-family: "Trebuchet MS", sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.packet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 0.7rem;
+}
+
+.badge {
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.18rem 0.5rem;
+  font-size: 0.72rem;
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.packet-section {
+  border-top: 1px solid var(--line);
+  padding-top: 0.65rem;
+}
+
+.packet-section p {
+  margin-top: 0.28rem;
+  color: var(--muted);
+}
+
+.packet-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.packet-actions button {
+  border: 1px solid var(--line);
+  background: white;
+  border-radius: 999px;
+  padding: 0.45rem 0.72rem;
+}
+
+.challenge-form {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.45rem;
+}
+
+.challenge-form label {
+  display: grid;
+  gap: 0.25rem;
+  color: var(--muted);
+  font-family: "Trebuchet MS", sans-serif;
+  font-size: 0.83rem;
+}
+
+.challenge-form input {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.4rem 0.55rem;
+  background: #fff;
+}
+
+.challenge-help {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.scene-attachment {
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  background: #fff;
+  padding: 0.55rem 0.65rem;
+}
+
+.scene-attachment h4 {
+  margin: 0 0 0.2rem;
+  font-size: 0.95rem;
+}
+
+.packet-queue {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 0.45rem;
+}
+
+.queue-item {
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 10px;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+}
+
+.queue-item.active {
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--line) 52%);
+  background: #fff8f4;
+}
+
+.controls {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.accessibility-controls {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.5rem 0.6rem;
+  margin: 0;
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.accessibility-controls legend {
+  padding: 0 0.3rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-family: "Trebuchet MS", sans-serif;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+}
+
+.keyboard-hint {
+  margin-top: 0.15rem;
+}
+
+.controls label {
+  display: grid;
+  gap: 0.25rem;
+  color: var(--muted);
+  font-family: "Trebuchet MS", sans-serif;
+  font-size: 0.86rem;
+}
+
+.controls input,
+.controls select {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  padding: 0.45rem 0.58rem;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.clock-readout {
+  color: var(--muted);
+}
+
+.collision-queue {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.collision-item {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  padding: 0.55rem 0.65rem;
+}
+
+.collision-item h3 {
+  font-size: 0.94rem;
+}
+
+.collision-item p {
+  margin-top: 0.2rem;
+  color: var(--muted);
+}
+
+.collision-item.priority-1 {
+  border-color: rgba(163, 38, 38, 0.65);
+  background: #fff3f1;
+}
+
+.collision-item.priority-2 {
+  border-color: rgba(163, 38, 38, 0.42);
+}
+
+.packet-focus.pressure-high {
+  border-color: rgba(163, 38, 38, 0.62);
+  box-shadow: inset 0 0 0 1px rgba(163, 38, 38, 0.18);
+}
+
+.packet-focus.pressure-medium {
+  border-color: rgba(143, 60, 45, 0.45);
+}
+
+#audio-toggle {
+  margin-top: 0.45rem;
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.48rem 0.72rem;
+}
+
+body.tempo-crisis .desk,
+body.tempo-media_storm .desk {
+  box-shadow: 0 22px 44px rgba(84, 44, 32, 0.2);
+}
+
+body.tempo-media_storm .phone-batch {
+  background: #fff8ef;
+}
+
+body.tempo-crisis .phone-batch.urgent,
+body.tempo-media_storm .phone-batch.urgent {
+  border-width: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  body.tempo-media_storm .panel.urgent-physical {
+    animation: tempo-alert-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes tempo-alert-pulse {
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-1px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+.detail-grid {
+  margin-top: 0.95rem;
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.panel-wide {
+  grid-column: span 3;
+}
+
+.summary {
+  margin: 0;
+  display: grid;
+  gap: 0.45rem 0.8rem;
+  grid-template-columns: 1fr auto;
+}
+
+.summary dt {
+  color: var(--muted);
+}
+
+.summary dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.progression,
+.action-result,
+.event-log {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.record-stat {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: linear-gradient(180deg, #fff 0%, #f8f1e5 100%);
+  padding: 0.55rem 0.65rem;
+  margin-bottom: 0.65rem;
+}
+
+.record-value {
+  font-weight: 600;
+}
+
+.phone-batches {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.55rem;
+}
+
+.phone-batch {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: linear-gradient(180deg, #ffffff 0%, #f5ede1 100%);
+  padding: 0.5rem 0.6rem;
+}
+
+.phone-batch h3 {
+  font-size: 0.9rem;
+  margin-bottom: 0.28rem;
+}
+
+.phone-batch ul {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--muted);
+}
+
+.phone-batch.urgent {
+  border-color: rgba(163, 38, 38, 0.55);
+  background: #fff3f1;
+}
+
+.phone-batch.severity-elevated {
+  border-color: rgba(143, 60, 45, 0.4);
+}
+
+.phone-batch.severity-high {
+  border-color: rgba(163, 38, 38, 0.52);
+}
+
+.phone-batch.severity-critical {
+  border-width: 2px;
+}
+
+.panel.urgent-physical {
+  box-shadow:
+    0 0 0 2px rgba(163, 38, 38, 0.22),
+    0 16px 26px rgba(163, 38, 38, 0.14);
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(163, 38, 38, 0.06),
+      rgba(163, 38, 38, 0.06) 8px,
+      rgba(255, 255, 255, 0.92) 8px,
+      rgba(255, 255, 255, 0.92) 16px
+    );
+}
+
+.bubble-lead {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: linear-gradient(180deg, #fff 0%, #f8f0e5 100%);
+  padding: 0.6rem 0.7rem;
+  margin-bottom: 0.6rem;
+}
+
+.bubble-lead h3 {
+  font-size: 1rem;
+}
+
+.bubble-lead p {
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+.supplement-list ul {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.supplement-list li {
+  color: var(--muted);
+}
+
+.progression-card,
+.action-card,
+.event-item {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.6rem 0.7rem;
+}
+
+.progression-card p,
+.progression-card li,
+.action-card p,
+.event-item p {
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 1100px) {
+  .desk {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .surface-column {
+    grid-column: span 2;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .shell {
+    width: min(100% - 1rem, 1240px);
+    padding-top: 0.9rem;
+  }
+
+  .topbar {
+    display: grid;
+    align-items: start;
+  }
+
+  .status {
+    text-align: left;
+  }
+
+  .interrupt {
+    display: grid;
+  }
+
+  .desk {
+    grid-template-columns: 1fr;
+  }
+
+  .surface-column {
+    grid-column: auto;
+    grid-template-columns: 1fr;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-wide {
+    grid-column: auto;
+  }
+
+  body.packet-fullscreen .desk {
+    display: block;
+    border-radius: 0;
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+    background: transparent;
+  }
+
+  body.packet-fullscreen .anchor-column,
+  body.packet-fullscreen .surface-column,
+  body.packet-fullscreen .detail-grid,
+  body.packet-fullscreen .topbar,
+  body.packet-fullscreen #interrupt {
+    display: none;
+  }
+
+  body.packet-fullscreen .packet-zone {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    border-radius: 0;
+    border: 0;
+    background: var(--paper);
+    padding: 1rem;
+    overflow-y: auto;
+    align-content: start;
+  }
+
+  body.packet-fullscreen .packet-focus {
+    min-height: min(72vh, 560px);
+  }
+}


### PR DESCRIPTION
## Summary
This PR moves the Tier 1 prototype from diagnostic-first to player-first UX for playtests.

### Included
- Baseline pass: hide debug scaffolding in normal mode and keep it under `?debug=1`.
- Interaction pass: convert challenge flow to single `Submit answer` action in normal mode.
- Readability pass: replace raw technical/event phrasing with player-facing copy.
- Guidance pass: add a persistent dynamic `Next action` prompt to keep loop direction clear.

## Why
Recent playtest feedback: readability and speed were acceptable, but overall flow felt confusing due to debug strings and prototype scaffolding.

## Validation
- `npm run build`
- `npm test` (43 passing)

## Issue
Closes #37
